### PR TITLE
Remove timezones on local datastore loads/saves

### DIFF
--- a/localdatastore.go
+++ b/localdatastore.go
@@ -322,6 +322,13 @@ func (ds *LocalDatastore) get(keyStr string) (item *dsItem, found bool) {
 	ds.mtx.Lock()
 	defer ds.mtx.Unlock()
 	item, found = ds.entities[keyStr]
+	if found {
+		for i, prop := range item.props {
+			if timeVal, ok := prop.Value.(time.Time); ok {
+				item.props[i].Value = timeVal.UTC()
+			}
+		}
+	}
 	return
 }
 
@@ -371,6 +378,11 @@ func (ds *LocalDatastore) NewKey(kind string, sId string, iId int64, parent *dat
 func (ds *LocalDatastore) put(keyStr string, item *dsItem) {
 	ds.mtx.Lock()
 	defer ds.mtx.Unlock()
+	for i, prop := range item.props {
+		if timeVal, ok := prop.Value.(time.Time); ok {
+			item.props[i].Value = timeVal.UTC()
+		}
+	}
 	ds.entities[keyStr] = item
 }
 


### PR DESCRIPTION
Appengine datastore has this behavior.  To make tests more representative
of reality, adding this behavior to localdatastore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pendo-io/appwrap/10)
<!-- Reviewable:end -->
