### PR TITLE
Don't pass logs through a channel, use logger directly instead

### DIFF
--- a/flexlogging.go
+++ b/flexlogging.go
@@ -39,11 +39,9 @@ func NewAppEngineLoggingService(c context.Context, aeInfo AppengineInfo, log Log
 	if err != nil {
 		panic(fmt.Sprintf("unable to configure stackdriver logger: %s", err.Error()))
 	}
-	
-	stackdriverClient := NewStackdriverClient(client)
-	logCh := make(chan LogMessage)
-	loggingService := newStackdriverLoggingService(stackdriverClient, aeInfo, logCh, log).(*StackdriverLoggingService)
-	go loggingService.processLogEntries()
+
+	stackdriverClient := newStackdriverClient(client)
+	loggingService := newStackdriverLoggingService(stackdriverClient, aeInfo, log).(*StackdriverLoggingService)
 
 	return loggingService
 }

--- a/stackdriverlogging_test.go
+++ b/stackdriverlogging_test.go
@@ -10,64 +10,69 @@ import (
 
 	"cloud.google.com/go/logging"
 	"github.com/pendo-io/appwrap"
+	"github.com/stretchr/testify/mock"
 	. "gopkg.in/check.v1"
 )
 
-type StackdriverLoggingFixture struct {
-	logCh chan LogMessage
-}
-
 type StackdriverLoggingTests struct {
-	ctx context.Context
+	appInfoMock *AppengineInfoMock
+	clientMock  *ClientMock
+	sl          *StackdriverLoggingService
+	ctx         context.Context
 }
 
 var _ = Suite(&StackdriverLoggingTests{})
 
 func (s *StackdriverLoggingTests) SetUpTest(c *C) {
 	s.ctx = appwrap.StubContext()
+	s.clientMock = &ClientMock{}
+	s.appInfoMock = &AppengineInfoMock{}
+
+	s.clientMock.On("SetUpOnError").Return().Once()
+	s.appInfoMock.On("ModuleName").Return("my-module").Once()
+	s.appInfoMock.On("AppID").Return("my-project").Once()
+	s.appInfoMock.On("VersionID").Return("my-version").Once()
+
+	s.sl = newStackdriverLoggingService(s.clientMock, s.appInfoMock, NullLogger{}).(*StackdriverLoggingService)
 }
 
-func (s *StackdriverLoggingTests) SetUpFixture(c *C) StackdriverLoggingFixture {
-	return StackdriverLoggingFixture{
-		logCh: make(chan LogMessage),
-	}
-}
+func assertParentLogEntry(c *C, log *StackdriverLogging, entry logging.Entry, severity logging.Severity, startTime time.Time) {
+	assertLogEntry(c, entry, severity, startTime)
 
-func (f *StackdriverLoggingFixture) assertMocks(c *C) {
-
-}
-
-func (f *StackdriverLoggingFixture) assertParentLogEntry(c *C, log *StackdriverLogging, logMessage LogMessage, severity logging.Severity, startTime time.Time) {
-	expectedLabels := logging.CommonLabels(map[string]string{
-		traceIdPath: log.traceContext,
-	})
-	c.Assert(logMessage.LogName, Equals, LogName(requestLogPath))
-	c.Assert(logMessage.CommonLabels, DeepEquals, expectedLabels)
-
-	entry := logMessage.Entry
-	c.Assert(entry.Labels, HasLen, 1)
-	c.Assert(entry.Labels["subscriptionId"], Equals, "12345")
 	c.Assert(entry.Payload, IsNil)
-	c.Assert(entry.Severity, Equals, severity)
-	c.Assert(entry.Timestamp.After(startTime), IsTrue)
-	c.Assert(entry.Timestamp.Before(time.Now()), IsTrue)
-	c.Assert(entry.Trace, Equals, "id-to-connect-logs")
-
 	c.Assert(entry.HTTPRequest.Latency <= time.Now().Sub(log.start), IsTrue)
 	c.Assert(entry.HTTPRequest.Request, DeepEquals, log.request)
 }
 
-func (f *StackdriverLoggingFixture) arrangeValidClient(r *http.Request) DataLogging {
+func assertChildLogEntry(c *C, entry logging.Entry, severity logging.Severity, startTime time.Time, payload interface{}) {
+	assertLogEntry(c, entry, severity, startTime)
+	c.Assert(entry.Payload, DeepEquals, payload)
+}
+
+func assertLogEntry(c *C, entry logging.Entry, severity logging.Severity, startTime time.Time) {
+	c.Assert(entry.Labels, HasLen, 1)
+	c.Assert(entry.Labels["subscriptionId"], Equals, "12345")
+	c.Assert(entry.Severity, Equals, severity)
+	c.Assert(entry.Timestamp.After(startTime), IsTrue)
+	c.Assert(entry.Timestamp.Before(time.Now()), IsTrue)
+	c.Assert(entry.Trace, Equals, "id-to-connect-logs")
+}
+
+func (s *StackdriverLoggingTests) arrangeValidClient(r *http.Request) DataLogging {
 	r.Header[headerCloudTraceContext] = []string{"id-to-connect-logs"}
-	return NewStackdriverLogging(map[string]string{}, LogName("pendo_test"), f.logCh, r, "")
+	s.clientMock.On("Logger", "pendo_test", mock.Anything).Return(&LoggerMock{}).Once()
+	s.clientMock.On("Logger", requestLogPath, mock.Anything).Return(&LoggerMock{}).Once()
+	return s.sl.newStackdriverLogging(map[string]string{}, LogName("pendo_test"), r, "")
 }
 
 func (s *StackdriverLoggingTests) TestLogSetup(c *C) {
-	f := s.SetUpFixture(c)
 	r := httptest.NewRequest(http.MethodGet, "http://localhost", strings.NewReader("Hello"))
 	r.Header[headerCloudTraceContext] = []string{"id-to-connect-logs"}
 
-	log := NewStackdriverLogging(map[string]string{"test": "this"}, LogName("pendo_test"), f.logCh, r, "").(*StackdriverLogging)
+	s.clientMock.On("Logger", "pendo_test", mock.Anything).Return(LoggerMock{}).Once()
+	s.clientMock.On("Logger", requestLogPath, mock.Anything).Return(LoggerMock{}).Once()
+
+	log := s.sl.CreateLog(map[string]string{"test": "this"}, LogName("pendo_test"), r, "").(*StackdriverLogging)
 
 	c.Assert(log.commonLabels, HasLen, 1)
 	c.Assert(log.commonLabels["test"], Equals, "this")
@@ -75,14 +80,14 @@ func (s *StackdriverLoggingTests) TestLogSetup(c *C) {
 	c.Assert(log.logName, Equals, LogName("pendo_test"))
 	c.Assert(log.traceContext, Equals, "id-to-connect-logs")
 	c.Assert(log.request, DeepEquals, r)
-	f.assertMocks(c)
 }
 
 func (s *StackdriverLoggingTests) TestLogSetupNoAppEngineTrace(c *C) {
-	f := s.SetUpFixture(c)
 	r := httptest.NewRequest(http.MethodGet, "http://localhost", strings.NewReader("Hello"))
 
-	log := NewStackdriverLogging(map[string]string{"test": "this"}, LogName("pendo_test"), f.logCh, r, "custom-trace-id").(*StackdriverLogging)
+	s.clientMock.On("Logger", "pendo_test", mock.Anything).Return(LoggerMock{}).Once()
+	s.clientMock.On("Logger", requestLogPath, mock.Anything).Return(LoggerMock{}).Once()
+	log := s.sl.CreateLog(map[string]string{"test": "this"}, LogName("pendo_test"), r, "custom-trace-id").(*StackdriverLogging)
 
 	c.Assert(log.commonLabels, HasLen, 1)
 	c.Assert(log.commonLabels["test"], Equals, "this")
@@ -90,13 +95,12 @@ func (s *StackdriverLoggingTests) TestLogSetupNoAppEngineTrace(c *C) {
 	c.Assert(log.logName, Equals, LogName("pendo_test"))
 	c.Assert(log.traceContext, Equals, "custom-trace-id")
 	c.Assert(log.request, DeepEquals, r)
-	f.assertMocks(c)
 }
 
 func (s *StackdriverLoggingTests) TestLogSetupRequestNil(c *C) {
-	f := s.SetUpFixture(c)
-
-	log := NewStackdriverLogging(map[string]string{"test": "this"}, LogName("pendo_test"), f.logCh, nil, "custom-trace-id").(*StackdriverLogging)
+	s.clientMock.On("Logger", "pendo_test", mock.Anything).Return(LoggerMock{}).Once()
+	s.clientMock.On("Logger", requestLogPath, mock.Anything).Return(LoggerMock{}).Once()
+	log := s.sl.CreateLog(map[string]string{"test": "this"}, LogName("pendo_test"), nil, "custom-trace-id").(*StackdriverLogging)
 
 	c.Assert(log.commonLabels, HasLen, 1)
 	c.Assert(log.commonLabels["test"], Equals, "this")
@@ -104,38 +108,32 @@ func (s *StackdriverLoggingTests) TestLogSetupRequestNil(c *C) {
 	c.Assert(log.logName, Equals, LogName("pendo_test"))
 	c.Assert(log.traceContext, Equals, "custom-trace-id")
 	c.Assert(log.request, IsNil)
-	f.assertMocks(c)
 }
 
 func (s *StackdriverLoggingTests) TestAddCommonLabel(c *C) {
-	f := s.SetUpFixture(c)
 	r := httptest.NewRequest(http.MethodGet, "http://localhost", strings.NewReader("Hello"))
-	log := f.arrangeValidClient(r).(*StackdriverLogging)
+	log := s.arrangeValidClient(r).(*StackdriverLogging)
 
 	log.AddLabel("test", "this")
 
 	c.Assert(log.commonLabels, HasLen, 1)
 	c.Assert(log.commonLabels["test"], Equals, "this")
-	f.assertMocks(c)
 }
 
 func (s *StackdriverLoggingTests) TestAddSameLabelTwice(c *C) {
-	f := s.SetUpFixture(c)
 	r := httptest.NewRequest(http.MethodGet, "http://localhost", strings.NewReader("Hello"))
-	log := f.arrangeValidClient(r).(*StackdriverLogging)
+	log := s.arrangeValidClient(r).(*StackdriverLogging)
 
 	log.AddLabel("test", "this")
 	log.AddLabel("test", "this")
 
 	c.Assert(log.commonLabels, HasLen, 1)
 	c.Assert(log.commonLabels["test"], Equals, "this")
-	f.assertMocks(c)
 }
 
 func (s *StackdriverLoggingTests) TestAddTwoLabel(c *C) {
-	f := s.SetUpFixture(c)
 	r := httptest.NewRequest(http.MethodGet, "http://localhost", strings.NewReader("Hello"))
-	log := f.arrangeValidClient(r).(*StackdriverLogging)
+	log := s.arrangeValidClient(r).(*StackdriverLogging)
 
 	log.AddLabel("test", "this")
 	log.AddLabel("test2", "this2")
@@ -143,36 +141,30 @@ func (s *StackdriverLoggingTests) TestAddTwoLabel(c *C) {
 	c.Assert(log.commonLabels, HasLen, 2)
 	c.Assert(log.commonLabels["test"], Equals, "this")
 	c.Assert(log.commonLabels["test2"], Equals, "this2")
-	f.assertMocks(c)
 }
 
 func (s *StackdriverLoggingTests) TestRemoveLabel(c *C) {
-	f := s.SetUpFixture(c)
 	r := httptest.NewRequest(http.MethodGet, "http://localhost", strings.NewReader("Hello"))
-	log := f.arrangeValidClient(r).(*StackdriverLogging)
+	log := s.arrangeValidClient(r).(*StackdriverLogging)
 
 	log.AddLabel("test", "this")
 	log.RemoveLabel("test")
 
 	c.Assert(log.commonLabels, HasLen, 0)
-	f.assertMocks(c)
 }
 
 func (s *StackdriverLoggingTests) TestRemoveLabelNoValidKey(c *C) {
-	f := s.SetUpFixture(c)
 	r := httptest.NewRequest(http.MethodGet, "http://localhost", strings.NewReader("Hello"))
-	log := f.arrangeValidClient(r).(*StackdriverLogging)
+	log := s.arrangeValidClient(r).(*StackdriverLogging)
 	log.RemoveLabel("test")
 
 	c.Assert(log.commonLabels, HasLen, 0)
-	f.assertMocks(c)
 }
 
 func (s *StackdriverLoggingTests) TestLogStringFormatFunctions(c *C) {
-	f := s.SetUpFixture(c)
 
 	r := httptest.NewRequest(http.MethodGet, "http://localhost", strings.NewReader("Hello"))
-	log := f.arrangeValidClient(r).(*StackdriverLogging)
+	log := s.arrangeValidClient(r).(*StackdriverLogging)
 	log.AddLabel("subscriptionId", "12345")
 
 	testCases := []struct {
@@ -188,27 +180,20 @@ func (s *StackdriverLoggingTests) TestLogStringFormatFunctions(c *C) {
 
 	for _, testCase := range testCases {
 		startTime := time.Now()
-
+		log.childLogger.(*LoggerMock).On("Log", mock.MatchedBy(func(entry logging.Entry) bool {
+			c.Assert(entry.Labels, HasLen, 1)
+			c.Assert(entry.Labels["subscriptionId"], Equals, "12345")
+			c.Assert(entry.Payload, Equals, fmt.Sprintf("This is a test %d, %s, and %d", 1, "two", 3))
+			c.Assert(entry.Severity, Equals, testCase.severity)
+			c.Assert(entry.Timestamp.After(startTime), IsTrue)
+			c.Assert(entry.Timestamp.Before(time.Now()), IsTrue)
+			c.Assert(entry.Trace, Equals, "id-to-connect-logs")
+			return true
+		})).Once()
 		testCase.logf("This is a test %d, %s, and %d", 1, "two", 3)
-
-		logMessage := <-f.logCh
-		expectedLabels := logging.CommonLabels(map[string]string{
-			traceIdPath: log.traceContext,
-		})
-		c.Assert(logMessage.LogName, Equals, LogName("pendo_test"))
-		c.Assert(logMessage.CommonLabels, DeepEquals, expectedLabels)
-
-		entry := logMessage.Entry
-		c.Assert(entry.Labels, HasLen, 1)
-		c.Assert(entry.Labels["subscriptionId"], Equals, "12345")
-		c.Assert(entry.Payload, Equals, fmt.Sprintf("This is a test %d, %s, and %d", 1, "two", 3))
-		c.Assert(entry.Severity, Equals, testCase.severity)
-		c.Assert(entry.Timestamp.After(startTime), IsTrue)
-		c.Assert(entry.Timestamp.Before(time.Now()), IsTrue)
-		c.Assert(entry.Trace, Equals, "id-to-connect-logs")
+		log.childLogger.(*LoggerMock).AssertExpectations(c)
 	}
 
-	f.assertMocks(c)
 }
 
 type testObject struct {
@@ -216,9 +201,8 @@ type testObject struct {
 }
 
 func (s *StackdriverLoggingTests) TestLogDataFunctions(c *C) {
-	f := s.SetUpFixture(c)
 	r := httptest.NewRequest(http.MethodGet, "http://localhost", strings.NewReader("Hello"))
-	log := f.arrangeValidClient(r).(*StackdriverLogging)
+	log := s.arrangeValidClient(r).(*StackdriverLogging)
 	log.AddLabel("subscriptionId", "12345")
 	testCases := []struct {
 		severity    logging.Severity
@@ -243,596 +227,344 @@ func (s *StackdriverLoggingTests) TestLogDataFunctions(c *C) {
 	}
 	for _, testCase := range testCases {
 		startTime := time.Now()
+		log.childLogger.(*LoggerMock).On("Log", mock.MatchedBy(func(entry logging.Entry) bool {
+			c.Assert(entry.Labels, HasLen, 1)
+			c.Assert(entry.Labels["subscriptionId"], Equals, "12345")
+			c.Assert(entry.Payload, DeepEquals, testCase.data)
+			c.Assert(entry.Severity, Equals, testCase.severity)
+			c.Assert(entry.Timestamp.After(startTime), IsTrue)
+			c.Assert(entry.Timestamp.Before(time.Now()), IsTrue)
+			c.Assert(entry.Trace, Equals, "id-to-connect-logs")
+			return true
+		})).Once()
 		testCase.logDataFunc(testCase.data)
-
-		logMessage := <-f.logCh
-		expectedLabels := logging.CommonLabels(map[string]string{
-			traceIdPath: log.traceContext,
-		})
-		c.Assert(logMessage.LogName, Equals, LogName("pendo_test"))
-		c.Assert(logMessage.CommonLabels, DeepEquals, expectedLabels)
-
-		entry := logMessage.Entry
-		c.Assert(entry.Labels, HasLen, 1)
-		c.Assert(entry.Labels["subscriptionId"], Equals, "12345")
-		c.Assert(entry.Payload, DeepEquals, testCase.data)
-		c.Assert(entry.Severity, Equals, testCase.severity)
-		c.Assert(entry.Timestamp.After(startTime), IsTrue)
-		c.Assert(entry.Timestamp.Before(time.Now()), IsTrue)
-		c.Assert(entry.Trace, Equals, "id-to-connect-logs")
+		log.childLogger.(*LoggerMock).AssertExpectations(c)
 	}
-
-	f.assertMocks(c)
 }
 
 func (s *StackdriverLoggingTests) TestCloseNoRequest(c *C) {
-	f := s.SetUpFixture(c)
 	w := httptest.NewRecorder()
-	log := NewStackdriverLogging(map[string]string{"test": "this"}, LogName("pendo_test"), f.logCh, nil, "custom-trace-id").(*StackdriverLogging)
+	s.clientMock.On("Logger", "pendo_test", mock.Anything).Return(&LoggerMock{}).Once()
+	s.clientMock.On("Logger", requestLogPath, mock.Anything).Return(&LoggerMock{}).Once()
+	log := s.sl.CreateLog(map[string]string{"test": "this"}, LogName("pendo_test"), nil, "custom-trace-id").(*StackdriverLogging)
 	log.AddLabel("subscriptionId", "12345")
 
-	doneCh := make(chan (bool))
-	var logs []LogMessage
-	go func() {
-		select {
-		case logMessage, ok := <-f.logCh:
-			if ok {
-				logs = append(logs, logMessage)
-			} else {
-				doneCh <- true
-				return
-			}
-		}
-	}()
-
+	// without a request, we shouldn't log any parent messages
+	log.parentLogger.(*LoggerMock).On("Flush").Return(nil).Once()
+	log.childLogger.(*LoggerMock).On("Flush").Return(nil).Once()
 	log.Close(w)
-	close(f.logCh)
-	<-doneCh
-
-	c.Assert(logs, HasLen, 0)
-	f.assertMocks(c)
+	log.parentLogger.(*LoggerMock).AssertExpectations(c)
+	log.childLogger.(*LoggerMock).AssertExpectations(c)
 }
 
 func (s *StackdriverLoggingTests) TestParentLogLevelDefault(c *C) {
-	f := s.SetUpFixture(c)
 	r := httptest.NewRequest(http.MethodGet, "http://localhost", strings.NewReader("Hello"))
 	w := httptest.NewRecorder()
-	log := f.arrangeValidClient(r).(*StackdriverLogging)
+	log := s.arrangeValidClient(r).(*StackdriverLogging)
 	log.AddLabel("subscriptionId", "12345")
-
 	r.Response = &http.Response{}
 	startTime := time.Now()
+	log.parentLogger.(*LoggerMock).On("Log", mock.MatchedBy(func(entry logging.Entry) bool {
+		assertParentLogEntry(c, log, entry, logging.Default, startTime)
+		return true
+	})).Once()
+	log.parentLogger.(*LoggerMock).On("Flush").Return(nil).Once()
+	log.childLogger.(*LoggerMock).On("Flush").Return(nil).Once()
 	log.Close(w)
-	logMessage := <-f.logCh
-
-	f.assertParentLogEntry(c, log, logMessage, logging.Default, startTime)
-	f.assertMocks(c)
+	log.parentLogger.(*LoggerMock).AssertExpectations(c)
+	log.childLogger.(*LoggerMock).AssertExpectations(c)
 }
 
-func (s *StackdriverLoggingTests) TestParentLogLevelDebug(c *C) {
-	f := s.SetUpFixture(c)
+func (s *StackdriverLoggingTests) TestParentLogLevelNonDefault(c *C) {
 	r := httptest.NewRequest(http.MethodGet, "http://localhost", strings.NewReader("Hello"))
-	w := httptest.NewRecorder()
-	log := f.arrangeValidClient(r).(*StackdriverLogging)
-	log.AddLabel("subscriptionId", "12345")
-
 	r.Response = &http.Response{}
+	payload := testObject{300}
+	testCases := []struct {
+		log      *StackdriverLogging
+		severity logging.Severity
+		logFunc  func(interface{})
+	}{
+		{s.arrangeValidClient(r).(*StackdriverLogging), logging.Debug, nil},
+		{s.arrangeValidClient(r).(*StackdriverLogging), logging.Info, nil},
+		{s.arrangeValidClient(r).(*StackdriverLogging), logging.Warning, nil},
+		{s.arrangeValidClient(r).(*StackdriverLogging), logging.Error, nil},
+		{s.arrangeValidClient(r).(*StackdriverLogging), logging.Critical, nil},
+	}
+	testCases[0].logFunc = testCases[0].log.Debug
+	testCases[0].log.AddLabel("subscriptionId", "12345")
+	testCases[1].logFunc = testCases[1].log.Info
+	testCases[1].log.AddLabel("subscriptionId", "12345")
+	testCases[2].logFunc = testCases[2].log.Warning
+	testCases[2].log.AddLabel("subscriptionId", "12345")
+	testCases[3].logFunc = testCases[3].log.Error
+	testCases[3].log.AddLabel("subscriptionId", "12345")
+	testCases[4].logFunc = testCases[4].log.Critical
+	testCases[4].log.AddLabel("subscriptionId", "12345")
 
-	startTime := time.Now()
-	log.Debug(testObject{300})
-	<-f.logCh
-	log.Close(w)
-	logMessage := <-f.logCh
+	for _, testCase := range testCases {
+		startTime := time.Now()
+		w := httptest.NewRecorder()
+		testCase.log.childLogger.(*LoggerMock).On("Log", mock.MatchedBy(func(entry logging.Entry) bool {
+			assertChildLogEntry(c, entry, testCase.severity, startTime, payload)
+			return true
+		})).Once()
+		testCase.logFunc(payload)
+		testCase.log.parentLogger.(*LoggerMock).On("Log", mock.MatchedBy(func(entry logging.Entry) bool {
+			assertParentLogEntry(c, testCase.log, entry, testCase.severity, startTime)
+			return true
+		})).Once()
+		testCase.log.parentLogger.(*LoggerMock).On("Flush").Return(nil).Once()
+		testCase.log.childLogger.(*LoggerMock).On("Flush").Return(nil).Once()
+		testCase.log.Close(w)
+		testCase.log.parentLogger.(*LoggerMock).AssertExpectations(c)
+		testCase.log.childLogger.(*LoggerMock).AssertExpectations(c)
+	}
 
-	f.assertParentLogEntry(c, log, logMessage, logging.Debug, startTime)
-	f.assertMocks(c)
+	formatTestCases := []struct {
+		log      *StackdriverLogging
+		severity logging.Severity
+		logFunc  func(string, ...interface{})
+	}{
+		{s.arrangeValidClient(r).(*StackdriverLogging), logging.Debug, nil},
+		{s.arrangeValidClient(r).(*StackdriverLogging), logging.Info, nil},
+		{s.arrangeValidClient(r).(*StackdriverLogging), logging.Warning, nil},
+		{s.arrangeValidClient(r).(*StackdriverLogging), logging.Error, nil},
+		{s.arrangeValidClient(r).(*StackdriverLogging), logging.Critical, nil},
+	}
+	formatTestCases[0].logFunc = formatTestCases[0].log.Debugf
+	formatTestCases[0].log.AddLabel("subscriptionId", "12345")
+	formatTestCases[1].logFunc = formatTestCases[1].log.Infof
+	formatTestCases[1].log.AddLabel("subscriptionId", "12345")
+	formatTestCases[2].logFunc = formatTestCases[2].log.Warningf
+	formatTestCases[2].log.AddLabel("subscriptionId", "12345")
+	formatTestCases[3].logFunc = formatTestCases[3].log.Errorf
+	formatTestCases[3].log.AddLabel("subscriptionId", "12345")
+	formatTestCases[4].logFunc = formatTestCases[4].log.Criticalf
+	formatTestCases[4].log.AddLabel("subscriptionId", "12345")
+	for _, testCase := range formatTestCases {
+		startTime := time.Now()
+		w := httptest.NewRecorder()
+		testCase.log.childLogger.(*LoggerMock).On("Log", mock.MatchedBy(func(entry logging.Entry) bool {
+			assertChildLogEntry(c, entry, testCase.severity, startTime, fmt.Sprintf("%v", payload))
+			return true
+		})).Once()
+		testCase.logFunc("%v", payload)
+		testCase.log.parentLogger.(*LoggerMock).On("Log", mock.MatchedBy(func(entry logging.Entry) bool {
+			assertParentLogEntry(c, testCase.log, entry, testCase.severity, startTime)
+			return true
+		})).Once()
+		testCase.log.parentLogger.(*LoggerMock).On("Flush").Return(nil).Once()
+		testCase.log.childLogger.(*LoggerMock).On("Flush").Return(nil).Once()
+		testCase.log.Close(w)
+		testCase.log.parentLogger.(*LoggerMock).AssertExpectations(c)
+		testCase.log.childLogger.(*LoggerMock).AssertExpectations(c)
+	}
 }
 
-func (s *StackdriverLoggingTests) TestParentLogLevelInfo(c *C) {
-	f := s.SetUpFixture(c)
+func (s *StackdriverLoggingTests) TestParentLogLevelHighOverrideLow(c *C) {
 	r := httptest.NewRequest(http.MethodGet, "http://localhost", strings.NewReader("Hello"))
-	w := httptest.NewRecorder()
-	log := f.arrangeValidClient(r).(*StackdriverLogging)
-	log.AddLabel("subscriptionId", "12345")
-
 	r.Response = &http.Response{}
+	payload := testObject{300}
+	testCases := []struct {
+		log          *StackdriverLogging
+		severityLow  logging.Severity
+		severityHigh logging.Severity
+		logFuncLow   func(interface{})
+		logFuncHigh  func(interface{})
+	}{
+		{s.arrangeValidClient(r).(*StackdriverLogging), logging.Debug, logging.Info, nil, nil},
+		{s.arrangeValidClient(r).(*StackdriverLogging), logging.Info, logging.Warning, nil, nil},
+		{s.arrangeValidClient(r).(*StackdriverLogging), logging.Warning, logging.Error, nil, nil},
+		{s.arrangeValidClient(r).(*StackdriverLogging), logging.Error, logging.Critical, nil, nil},
+	}
+	testCases[0].logFuncLow = testCases[0].log.Debug
+	testCases[0].logFuncHigh = testCases[0].log.Info
+	testCases[0].log.AddLabel("subscriptionId", "12345")
+	testCases[1].logFuncLow = testCases[1].log.Info
+	testCases[1].logFuncHigh = testCases[1].log.Warning
+	testCases[1].log.AddLabel("subscriptionId", "12345")
+	testCases[2].logFuncLow = testCases[2].log.Warning
+	testCases[2].logFuncHigh = testCases[2].log.Error
+	testCases[2].log.AddLabel("subscriptionId", "12345")
+	testCases[3].logFuncLow = testCases[3].log.Error
+	testCases[3].logFuncHigh = testCases[3].log.Critical
+	testCases[3].log.AddLabel("subscriptionId", "12345")
 
-	startTime := time.Now()
-	log.Info(testObject{300})
-	<-f.logCh
-	log.Close(w)
-	logMessage := <-f.logCh
+	for _, testCase := range testCases {
+		startTime := time.Now()
+		w := httptest.NewRecorder()
+		testCase.log.childLogger.(*LoggerMock).On("Log", mock.MatchedBy(func(entry logging.Entry) bool {
+			assertChildLogEntry(c, entry, testCase.severityLow, startTime, payload)
+			return true
+		})).Once()
+		testCase.logFuncLow(payload)
+		testCase.log.childLogger.(*LoggerMock).On("Log", mock.MatchedBy(func(entry logging.Entry) bool {
+			assertChildLogEntry(c, entry, testCase.severityHigh, startTime, payload)
+			return true
+		})).Once()
+		testCase.logFuncHigh(payload)
+		testCase.log.parentLogger.(*LoggerMock).On("Log", mock.MatchedBy(func(entry logging.Entry) bool {
+			assertParentLogEntry(c, testCase.log, entry, testCase.severityHigh, startTime)
+			return true
+		})).Once()
+		testCase.log.parentLogger.(*LoggerMock).On("Flush").Return(nil).Once()
+		testCase.log.childLogger.(*LoggerMock).On("Flush").Return(nil).Once()
+		testCase.log.Close(w)
+		testCase.log.parentLogger.(*LoggerMock).AssertExpectations(c)
+		testCase.log.childLogger.(*LoggerMock).AssertExpectations(c)
+		testCase.log.parentLogger.(*LoggerMock).AssertExpectations(c)
+	}
 
-	f.assertParentLogEntry(c, log, logMessage, logging.Info, startTime)
-	f.assertMocks(c)
+	formatTestCases := []struct {
+		log          *StackdriverLogging
+		severityLow  logging.Severity
+		severityHigh logging.Severity
+		logFuncLow   func(string, ...interface{})
+		logFuncHigh  func(string, ...interface{})
+	}{
+		{s.arrangeValidClient(r).(*StackdriverLogging), logging.Debug, logging.Info, nil, nil},
+		{s.arrangeValidClient(r).(*StackdriverLogging), logging.Info, logging.Warning, nil, nil},
+		{s.arrangeValidClient(r).(*StackdriverLogging), logging.Warning, logging.Error, nil, nil},
+		{s.arrangeValidClient(r).(*StackdriverLogging), logging.Error, logging.Critical, nil, nil},
+	}
+	formatTestCases[0].logFuncLow = formatTestCases[0].log.Debugf
+	formatTestCases[0].logFuncHigh = formatTestCases[0].log.Infof
+	formatTestCases[0].log.AddLabel("subscriptionId", "12345")
+	formatTestCases[1].logFuncLow = formatTestCases[1].log.Infof
+	formatTestCases[1].logFuncHigh = formatTestCases[1].log.Warningf
+	formatTestCases[1].log.AddLabel("subscriptionId", "12345")
+	formatTestCases[2].logFuncLow = formatTestCases[2].log.Warningf
+	formatTestCases[2].logFuncHigh = formatTestCases[2].log.Errorf
+	formatTestCases[2].log.AddLabel("subscriptionId", "12345")
+	formatTestCases[3].logFuncLow = formatTestCases[3].log.Errorf
+	formatTestCases[3].logFuncHigh = formatTestCases[3].log.Criticalf
+	formatTestCases[3].log.AddLabel("subscriptionId", "12345")
+
+	for _, testCase := range formatTestCases {
+		startTime := time.Now()
+		w := httptest.NewRecorder()
+		testCase.log.childLogger.(*LoggerMock).On("Log", mock.MatchedBy(func(entry logging.Entry) bool {
+			assertChildLogEntry(c, entry, testCase.severityLow, startTime, fmt.Sprintf("%v", payload))
+			return true
+		})).Once()
+		testCase.logFuncLow("%v", payload)
+		testCase.log.childLogger.(*LoggerMock).On("Log", mock.MatchedBy(func(entry logging.Entry) bool {
+			assertChildLogEntry(c, entry, testCase.severityHigh, startTime, fmt.Sprintf("%v", payload))
+			return true
+		})).Once()
+		testCase.logFuncHigh("%v", payload)
+		testCase.log.parentLogger.(*LoggerMock).On("Log", mock.MatchedBy(func(entry logging.Entry) bool {
+			assertParentLogEntry(c, testCase.log, entry, testCase.severityHigh, startTime)
+			return true
+		})).Once()
+		testCase.log.parentLogger.(*LoggerMock).On("Flush").Return(nil).Once()
+		testCase.log.childLogger.(*LoggerMock).On("Flush").Return(nil).Once()
+		testCase.log.Close(w)
+		testCase.log.parentLogger.(*LoggerMock).AssertExpectations(c)
+		testCase.log.childLogger.(*LoggerMock).AssertExpectations(c)
+		testCase.log.parentLogger.(*LoggerMock).AssertExpectations(c)
+	}
 }
 
-func (s *StackdriverLoggingTests) TestParentLogLevelWarning(c *C) {
-	f := s.SetUpFixture(c)
+func (s *StackdriverLoggingTests) TestParentLogLevelLowNotOverrideHigh(c *C) {
 	r := httptest.NewRequest(http.MethodGet, "http://localhost", strings.NewReader("Hello"))
-	w := httptest.NewRecorder()
-	log := f.arrangeValidClient(r).(*StackdriverLogging)
-	log.AddLabel("subscriptionId", "12345")
-
 	r.Response = &http.Response{}
-
-	startTime := time.Now()
-	log.Warning(testObject{300})
-	<-f.logCh
-	log.Close(w)
-	logMessage := <-f.logCh
-
-	f.assertParentLogEntry(c, log, logMessage, logging.Warning, startTime)
-	f.assertMocks(c)
-}
-
-func (s *StackdriverLoggingTests) TestParentLogLevelError(c *C) {
-	f := s.SetUpFixture(c)
-	r := httptest.NewRequest(http.MethodGet, "http://localhost", strings.NewReader("Hello"))
-	w := httptest.NewRecorder()
-	log := f.arrangeValidClient(r).(*StackdriverLogging)
-	log.AddLabel("subscriptionId", "12345")
-
-	r.Response = &http.Response{}
-
-	startTime := time.Now()
-	log.Error(testObject{300})
-	<-f.logCh
-	log.Close(w)
-	logMessage := <-f.logCh
-
-	f.assertParentLogEntry(c, log, logMessage, logging.Error, startTime)
-	f.assertMocks(c)
-}
-
-func (s *StackdriverLoggingTests) TestParentLogLevelCritical(c *C) {
-	f := s.SetUpFixture(c)
-	r := httptest.NewRequest(http.MethodGet, "http://localhost", strings.NewReader("Hello"))
-	w := httptest.NewRecorder()
-	log := f.arrangeValidClient(r).(*StackdriverLogging)
-	log.AddLabel("subscriptionId", "12345")
-
-	r.Response = &http.Response{}
-
-	startTime := time.Now()
-	log.Critical(testObject{300})
-	<-f.logCh
-	log.Close(w)
-	logMessage := <-f.logCh
-
-	f.assertParentLogEntry(c, log, logMessage, logging.Critical, startTime)
-	f.assertMocks(c)
-}
-
-func (s *StackdriverLoggingTests) TestParentLogLevelDebugToInfo(c *C) {
-	f := s.SetUpFixture(c)
-	r := httptest.NewRequest(http.MethodGet, "http://localhost", strings.NewReader("Hello"))
-	w := httptest.NewRecorder()
-	log := f.arrangeValidClient(r).(*StackdriverLogging)
-	log.AddLabel("subscriptionId", "12345")
-
-	r.Response = &http.Response{}
-
-	startTime := time.Now()
-	log.Debug(testObject{300})
-	<-f.logCh
-
-	log.Info(testObject{299})
-	<-f.logCh
-	log.Close(w)
-	logMessage := <-f.logCh
-
-	f.assertParentLogEntry(c, log, logMessage, logging.Info, startTime)
-	f.assertMocks(c)
-}
-
-func (s *StackdriverLoggingTests) TestParentLogLevelInfoToWarning(c *C) {
-	f := s.SetUpFixture(c)
-	r := httptest.NewRequest(http.MethodGet, "http://localhost", strings.NewReader("Hello"))
-	w := httptest.NewRecorder()
-	log := f.arrangeValidClient(r).(*StackdriverLogging)
-	log.AddLabel("subscriptionId", "12345")
-	r.Response = &http.Response{}
-
-	startTime := time.Now()
-	log.Info(testObject{300})
-	<-f.logCh
-
-	log.Warning(testObject{299})
-	<-f.logCh
-	log.Close(w)
-	logMessage := <-f.logCh
-
-	f.assertParentLogEntry(c, log, logMessage, logging.Warning, startTime)
-	f.assertMocks(c)
-}
-
-func (s *StackdriverLoggingTests) TestParentLogLevelWarningToError(c *C) {
-	f := s.SetUpFixture(c)
-	r := httptest.NewRequest(http.MethodGet, "http://localhost", strings.NewReader("Hello"))
-	w := httptest.NewRecorder()
-	log := f.arrangeValidClient(r).(*StackdriverLogging)
-	log.AddLabel("subscriptionId", "12345")
-	r.Response = &http.Response{}
-
-	startTime := time.Now()
-	log.Warning(testObject{300})
-	<-f.logCh
-
-	log.Error(testObject{299})
-	<-f.logCh
-	log.Close(w)
-	logMessage := <-f.logCh
-
-	f.assertParentLogEntry(c, log, logMessage, logging.Error, startTime)
-	f.assertMocks(c)
-}
-
-func (s *StackdriverLoggingTests) TestParentLogLevelErrorToCritical(c *C) {
-	f := s.SetUpFixture(c)
-	r := httptest.NewRequest(http.MethodGet, "http://localhost", strings.NewReader("Hello"))
-	w := httptest.NewRecorder()
-	log := f.arrangeValidClient(r).(*StackdriverLogging)
-	log.AddLabel("subscriptionId", "12345")
-	r.Response = &http.Response{}
-
-	startTime := time.Now()
-	log.Error(testObject{300})
-	<-f.logCh
-
-	log.Critical(testObject{299})
-	<-f.logCh
-	log.Close(w)
-	logMessage := <-f.logCh
-
-	f.assertParentLogEntry(c, log, logMessage, logging.Critical, startTime)
-	f.assertMocks(c)
-}
-
-func (s *StackdriverLoggingTests) TestParentLogLevelInfoDebug(c *C) {
-	f := s.SetUpFixture(c)
-	r := httptest.NewRequest(http.MethodGet, "http://localhost", strings.NewReader("Hello"))
-	w := httptest.NewRecorder()
-	log := f.arrangeValidClient(r).(*StackdriverLogging)
-	log.AddLabel("subscriptionId", "12345")
-	r.Response = &http.Response{}
-
-	startTime := time.Now()
-	log.Info(testObject{300})
-	<-f.logCh
-
-	log.Debug(testObject{299})
-	<-f.logCh
-	log.Close(w)
-	logMessage := <-f.logCh
-
-	f.assertParentLogEntry(c, log, logMessage, logging.Info, startTime)
-	f.assertMocks(c)
-}
-
-func (s *StackdriverLoggingTests) TestParentLogLevelWarningInfo(c *C) {
-	f := s.SetUpFixture(c)
-	r := httptest.NewRequest(http.MethodGet, "http://localhost", strings.NewReader("Hello"))
-	w := httptest.NewRecorder()
-	log := f.arrangeValidClient(r).(*StackdriverLogging)
-	log.AddLabel("subscriptionId", "12345")
-	r.Response = &http.Response{}
-
-	startTime := time.Now()
-	log.Warning(testObject{300})
-	<-f.logCh
-
-	log.Info(testObject{299})
-	<-f.logCh
-	log.Close(w)
-	logMessage := <-f.logCh
-
-	f.assertParentLogEntry(c, log, logMessage, logging.Warning, startTime)
-	f.assertMocks(c)
-}
-
-func (s *StackdriverLoggingTests) TestParentLogLevelErrorWarning(c *C) {
-	f := s.SetUpFixture(c)
-	r := httptest.NewRequest(http.MethodGet, "http://localhost", strings.NewReader("Hello"))
-	w := httptest.NewRecorder()
-	log := f.arrangeValidClient(r).(*StackdriverLogging)
-	log.AddLabel("subscriptionId", "12345")
-	r.Response = &http.Response{}
-
-	startTime := time.Now()
-	log.Error(testObject{300})
-	<-f.logCh
-
-	log.Warning(testObject{299})
-	<-f.logCh
-	log.Close(w)
-	logMessage := <-f.logCh
-
-	f.assertParentLogEntry(c, log, logMessage, logging.Error, startTime)
-	f.assertMocks(c)
-}
-
-func (s *StackdriverLoggingTests) TestParentLogLevelCriticalError(c *C) {
-	f := s.SetUpFixture(c)
-	r := httptest.NewRequest(http.MethodGet, "http://localhost", strings.NewReader("Hello"))
-	w := httptest.NewRecorder()
-	log := f.arrangeValidClient(r).(*StackdriverLogging)
-	log.AddLabel("subscriptionId", "12345")
-	r.Response = &http.Response{}
-
-	startTime := time.Now()
-	log.Critical(testObject{300})
-	<-f.logCh
-
-	log.Error(testObject{299})
-	<-f.logCh
-	log.Close(w)
-	logMessage := <-f.logCh
-
-	f.assertParentLogEntry(c, log, logMessage, logging.Critical, startTime)
-	f.assertMocks(c)
-}
-
-func (s *StackdriverLoggingTests) TestParentLogFormatDebug(c *C) {
-	f := s.SetUpFixture(c)
-	r := httptest.NewRequest(http.MethodGet, "http://localhost", strings.NewReader("Hello"))
-	w := httptest.NewRecorder()
-	log := f.arrangeValidClient(r).(*StackdriverLogging)
-	log.AddLabel("subscriptionId", "12345")
-
-	r.Response = &http.Response{}
-
-	startTime := time.Now()
-	log.Debugf("This is a test")
-	<-f.logCh
-	log.Close(w)
-	logMessage := <-f.logCh
-
-	f.assertParentLogEntry(c, log, logMessage, logging.Debug, startTime)
-	f.assertMocks(c)
-}
-
-func (s *StackdriverLoggingTests) TestParentLogFormatInfo(c *C) {
-	f := s.SetUpFixture(c)
-	r := httptest.NewRequest(http.MethodGet, "http://localhost", strings.NewReader("Hello"))
-	w := httptest.NewRecorder()
-	log := f.arrangeValidClient(r).(*StackdriverLogging)
-	log.AddLabel("subscriptionId", "12345")
-
-	r.Response = &http.Response{}
-
-	startTime := time.Now()
-	log.Infof("This is a test")
-	<-f.logCh
-	log.Close(w)
-	logMessage := <-f.logCh
-
-	f.assertParentLogEntry(c, log, logMessage, logging.Info, startTime)
-	f.assertMocks(c)
-}
-
-func (s *StackdriverLoggingTests) TestParentLogFormatWarning(c *C) {
-	f := s.SetUpFixture(c)
-	r := httptest.NewRequest(http.MethodGet, "http://localhost", strings.NewReader("Hello"))
-	w := httptest.NewRecorder()
-	log := f.arrangeValidClient(r).(*StackdriverLogging)
-	log.AddLabel("subscriptionId", "12345")
-
-	r.Response = &http.Response{}
-
-	startTime := time.Now()
-	log.Warningf("This is a test")
-	<-f.logCh
-	log.Close(w)
-	logMessage := <-f.logCh
-
-	f.assertParentLogEntry(c, log, logMessage, logging.Warning, startTime)
-	f.assertMocks(c)
-}
-
-func (s *StackdriverLoggingTests) TestParentLogFormatError(c *C) {
-	f := s.SetUpFixture(c)
-	r := httptest.NewRequest(http.MethodGet, "http://localhost", strings.NewReader("Hello"))
-	w := httptest.NewRecorder()
-	log := f.arrangeValidClient(r).(*StackdriverLogging)
-	log.AddLabel("subscriptionId", "12345")
-
-	r.Response = &http.Response{}
-
-	startTime := time.Now()
-	log.Errorf("This is a test")
-	<-f.logCh
-	log.Close(w)
-	logMessage := <-f.logCh
-
-	f.assertParentLogEntry(c, log, logMessage, logging.Error, startTime)
-	f.assertMocks(c)
-}
-
-func (s *StackdriverLoggingTests) TestParentLogFormatCritical(c *C) {
-	f := s.SetUpFixture(c)
-	r := httptest.NewRequest(http.MethodGet, "http://localhost", strings.NewReader("Hello"))
-	w := httptest.NewRecorder()
-	log := f.arrangeValidClient(r).(*StackdriverLogging)
-	log.AddLabel("subscriptionId", "12345")
-
-	r.Response = &http.Response{}
-
-	startTime := time.Now()
-	log.Criticalf("This is a test")
-	<-f.logCh
-	log.Close(w)
-	logMessage := <-f.logCh
-
-	f.assertParentLogEntry(c, log, logMessage, logging.Critical, startTime)
-	f.assertMocks(c)
-}
-
-func (s *StackdriverLoggingTests) TestParentLogFormatLevelDebugToInfo(c *C) {
-	f := s.SetUpFixture(c)
-	r := httptest.NewRequest(http.MethodGet, "http://localhost", strings.NewReader("Hello"))
-	w := httptest.NewRecorder()
-	log := f.arrangeValidClient(r).(*StackdriverLogging)
-	log.AddLabel("subscriptionId", "12345")
-
-	r.Response = &http.Response{}
-
-	startTime := time.Now()
-	log.Debugf("This is a test")
-	<-f.logCh
-
-	log.Infof("This is a test")
-	<-f.logCh
-	log.Close(w)
-	logMessage := <-f.logCh
-
-	f.assertParentLogEntry(c, log, logMessage, logging.Info, startTime)
-	f.assertMocks(c)
-}
-
-func (s *StackdriverLoggingTests) TestParentLogFormatLevelInfoToWarning(c *C) {
-	f := s.SetUpFixture(c)
-	r := httptest.NewRequest(http.MethodGet, "http://localhost", strings.NewReader("Hello"))
-	w := httptest.NewRecorder()
-	log := f.arrangeValidClient(r).(*StackdriverLogging)
-	log.AddLabel("subscriptionId", "12345")
-	r.Response = &http.Response{}
-
-	startTime := time.Now()
-	log.Infof("This is a test")
-	<-f.logCh
-
-	log.Warningf("This is a test")
-	<-f.logCh
-	log.Close(w)
-	logMessage := <-f.logCh
-
-	f.assertParentLogEntry(c, log, logMessage, logging.Warning, startTime)
-	f.assertMocks(c)
-}
-
-func (s *StackdriverLoggingTests) TestParentLogFormatLevelWarningToError(c *C) {
-	f := s.SetUpFixture(c)
-	r := httptest.NewRequest(http.MethodGet, "http://localhost", strings.NewReader("Hello"))
-	w := httptest.NewRecorder()
-	log := f.arrangeValidClient(r).(*StackdriverLogging)
-	log.AddLabel("subscriptionId", "12345")
-	r.Response = &http.Response{}
-
-	startTime := time.Now()
-	log.Warningf("This is a test")
-	<-f.logCh
-
-	log.Errorf("This is a test")
-	<-f.logCh
-	log.Close(w)
-	logMessage := <-f.logCh
-
-	f.assertParentLogEntry(c, log, logMessage, logging.Error, startTime)
-	f.assertMocks(c)
-}
-
-func (s *StackdriverLoggingTests) TestParentLogFormatLevelErrorToCritical(c *C) {
-	f := s.SetUpFixture(c)
-	r := httptest.NewRequest(http.MethodGet, "http://localhost", strings.NewReader("Hello"))
-	w := httptest.NewRecorder()
-	log := f.arrangeValidClient(r).(*StackdriverLogging)
-	log.AddLabel("subscriptionId", "12345")
-	r.Response = &http.Response{}
-
-	startTime := time.Now()
-	log.Errorf("This is a test")
-	<-f.logCh
-
-	log.Criticalf("This is a test")
-	<-f.logCh
-	log.Close(w)
-	logMessage := <-f.logCh
-
-	f.assertParentLogEntry(c, log, logMessage, logging.Critical, startTime)
-	f.assertMocks(c)
-}
-
-func (s *StackdriverLoggingTests) TestParentLogFormatLevelInfoDebug(c *C) {
-	f := s.SetUpFixture(c)
-	r := httptest.NewRequest(http.MethodGet, "http://localhost", strings.NewReader("Hello"))
-	w := httptest.NewRecorder()
-	log := f.arrangeValidClient(r).(*StackdriverLogging)
-	log.AddLabel("subscriptionId", "12345")
-	r.Response = &http.Response{}
-
-	startTime := time.Now()
-	log.Infof("This is a test")
-	<-f.logCh
-
-	log.Debugf("This is a test")
-	<-f.logCh
-	log.Close(w)
-	logMessage := <-f.logCh
-
-	f.assertParentLogEntry(c, log, logMessage, logging.Info, startTime)
-	f.assertMocks(c)
-}
-
-func (s *StackdriverLoggingTests) TestParentLogFormatLevelWarningInfo(c *C) {
-	f := s.SetUpFixture(c)
-	r := httptest.NewRequest(http.MethodGet, "http://localhost", strings.NewReader("Hello"))
-	w := httptest.NewRecorder()
-	log := f.arrangeValidClient(r).(*StackdriverLogging)
-	log.AddLabel("subscriptionId", "12345")
-	r.Response = &http.Response{}
-
-	startTime := time.Now()
-	log.Warningf("This is a test")
-	<-f.logCh
-
-	log.Infof("This is a test")
-	<-f.logCh
-	log.Close(w)
-	logMessage := <-f.logCh
-
-	f.assertParentLogEntry(c, log, logMessage, logging.Warning, startTime)
-	f.assertMocks(c)
-}
-
-func (s *StackdriverLoggingTests) TestParentLogFormatLevelErrorWarning(c *C) {
-	f := s.SetUpFixture(c)
-	r := httptest.NewRequest(http.MethodGet, "http://localhost", strings.NewReader("Hello"))
-	w := httptest.NewRecorder()
-	log := f.arrangeValidClient(r).(*StackdriverLogging)
-	log.AddLabel("subscriptionId", "12345")
-	r.Response = &http.Response{}
-
-	startTime := time.Now()
-	log.Errorf("This is a test")
-	<-f.logCh
-
-	log.Warningf("This is a test")
-	<-f.logCh
-	log.Close(w)
-	logMessage := <-f.logCh
-
-	f.assertParentLogEntry(c, log, logMessage, logging.Error, startTime)
-	f.assertMocks(c)
-}
-
-func (s *StackdriverLoggingTests) TestParentLogFormatLevelCriticalError(c *C) {
-	f := s.SetUpFixture(c)
-	r := httptest.NewRequest(http.MethodGet, "http://localhost", strings.NewReader("Hello"))
-	w := httptest.NewRecorder()
-	log := f.arrangeValidClient(r).(*StackdriverLogging)
-	log.AddLabel("subscriptionId", "12345")
-	r.Response = &http.Response{}
-
-	startTime := time.Now()
-	log.Criticalf("This is a test")
-	<-f.logCh
-
-	log.Errorf("This is a test")
-	<-f.logCh
-	log.Close(w)
-	logMessage := <-f.logCh
-
-	f.assertParentLogEntry(c, log, logMessage, logging.Critical, startTime)
-	f.assertMocks(c)
+	payload := testObject{300}
+	testCases := []struct {
+		log          *StackdriverLogging
+		severityLow  logging.Severity
+		severityHigh logging.Severity
+		logFuncLow   func(interface{})
+		logFuncHigh  func(interface{})
+	}{
+		{s.arrangeValidClient(r).(*StackdriverLogging), logging.Debug, logging.Info, nil, nil},
+		{s.arrangeValidClient(r).(*StackdriverLogging), logging.Info, logging.Warning, nil, nil},
+		{s.arrangeValidClient(r).(*StackdriverLogging), logging.Warning, logging.Error, nil, nil},
+		{s.arrangeValidClient(r).(*StackdriverLogging), logging.Error, logging.Critical, nil, nil},
+	}
+	testCases[0].logFuncLow = testCases[0].log.Debug
+	testCases[0].logFuncHigh = testCases[0].log.Info
+	testCases[0].log.AddLabel("subscriptionId", "12345")
+	testCases[1].logFuncLow = testCases[1].log.Info
+	testCases[1].logFuncHigh = testCases[1].log.Warning
+	testCases[1].log.AddLabel("subscriptionId", "12345")
+	testCases[2].logFuncLow = testCases[2].log.Warning
+	testCases[2].logFuncHigh = testCases[2].log.Error
+	testCases[2].log.AddLabel("subscriptionId", "12345")
+	testCases[3].logFuncLow = testCases[3].log.Error
+	testCases[3].logFuncHigh = testCases[3].log.Critical
+	testCases[3].log.AddLabel("subscriptionId", "12345")
+
+	for _, testCase := range testCases {
+		startTime := time.Now()
+		w := httptest.NewRecorder()
+		testCase.log.childLogger.(*LoggerMock).On("Log", mock.MatchedBy(func(entry logging.Entry) bool {
+			assertChildLogEntry(c, entry, testCase.severityHigh, startTime, payload)
+			return true
+		})).Once()
+		testCase.logFuncHigh(payload)
+		testCase.log.childLogger.(*LoggerMock).On("Log", mock.MatchedBy(func(entry logging.Entry) bool {
+			assertChildLogEntry(c, entry, testCase.severityLow, startTime, payload)
+			return true
+		})).Once()
+		testCase.logFuncLow(payload)
+		testCase.log.parentLogger.(*LoggerMock).On("Log", mock.MatchedBy(func(entry logging.Entry) bool {
+			assertParentLogEntry(c, testCase.log, entry, testCase.severityHigh, startTime)
+			return true
+		})).Once()
+		testCase.log.parentLogger.(*LoggerMock).On("Flush").Return(nil).Once()
+		testCase.log.childLogger.(*LoggerMock).On("Flush").Return(nil).Once()
+		testCase.log.Close(w)
+		testCase.log.parentLogger.(*LoggerMock).AssertExpectations(c)
+		testCase.log.childLogger.(*LoggerMock).AssertExpectations(c)
+	}
+
+	formatTestCases := []struct {
+		log          *StackdriverLogging
+		severityLow  logging.Severity
+		severityHigh logging.Severity
+		logFuncLow   func(string, ...interface{})
+		logFuncHigh  func(string, ...interface{})
+	}{
+		{s.arrangeValidClient(r).(*StackdriverLogging), logging.Debug, logging.Info, nil, nil},
+		{s.arrangeValidClient(r).(*StackdriverLogging), logging.Info, logging.Warning, nil, nil},
+		{s.arrangeValidClient(r).(*StackdriverLogging), logging.Warning, logging.Error, nil, nil},
+		{s.arrangeValidClient(r).(*StackdriverLogging), logging.Error, logging.Critical, nil, nil},
+	}
+	formatTestCases[0].logFuncLow = formatTestCases[0].log.Debugf
+	formatTestCases[0].logFuncHigh = formatTestCases[0].log.Infof
+	formatTestCases[0].log.AddLabel("subscriptionId", "12345")
+	formatTestCases[1].logFuncLow = formatTestCases[1].log.Infof
+	formatTestCases[1].logFuncHigh = formatTestCases[1].log.Warningf
+	formatTestCases[1].log.AddLabel("subscriptionId", "12345")
+	formatTestCases[2].logFuncLow = formatTestCases[2].log.Warningf
+	formatTestCases[2].logFuncHigh = formatTestCases[2].log.Errorf
+	formatTestCases[2].log.AddLabel("subscriptionId", "12345")
+	formatTestCases[3].logFuncLow = formatTestCases[3].log.Errorf
+	formatTestCases[3].logFuncHigh = formatTestCases[3].log.Criticalf
+	formatTestCases[3].log.AddLabel("subscriptionId", "12345")
+
+	for _, testCase := range formatTestCases {
+		startTime := time.Now()
+		w := httptest.NewRecorder()
+		testCase.log.childLogger.(*LoggerMock).On("Log", mock.MatchedBy(func(entry logging.Entry) bool {
+			assertChildLogEntry(c, entry, testCase.severityHigh, startTime, fmt.Sprintf("%v", payload))
+			return true
+		})).Once()
+		testCase.logFuncHigh("%v", payload)
+		testCase.log.childLogger.(*LoggerMock).On("Log", mock.MatchedBy(func(entry logging.Entry) bool {
+			assertChildLogEntry(c, entry, testCase.severityLow, startTime, fmt.Sprintf("%v", payload))
+			return true
+		})).Once()
+		testCase.logFuncLow("%v", payload)
+		testCase.log.parentLogger.(*LoggerMock).On("Log", mock.MatchedBy(func(entry logging.Entry) bool {
+			assertParentLogEntry(c, testCase.log, entry, testCase.severityHigh, startTime)
+			return true
+		})).Once()
+		testCase.log.parentLogger.(*LoggerMock).On("Flush").Return(nil).Once()
+		testCase.log.childLogger.(*LoggerMock).On("Flush").Return(nil).Once()
+		testCase.log.Close(w)
+		testCase.log.parentLogger.(*LoggerMock).AssertExpectations(c)
+		testCase.log.childLogger.(*LoggerMock).AssertExpectations(c)
+	}
 }


### PR DESCRIPTION
Passing over a channel caused immense memory pressure with high rate logging.

See APP 14937 and APP 14934

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pendo-io/appwrap/17)
<!-- Reviewable:end -->
