### PR TITLE
Fix panic in GetMulti - attempting to cast string to byte slice

### DIFF
--- a/memorystore.go
+++ b/memorystore.go
@@ -328,7 +328,7 @@ func (ms Memorystore) GetMulti(keys []string) (map[string]*CacheItem, error) {
 			// Not found
 			continue
 		}
-		valBytes := val.([]byte)
+		valBytes := ms.convertToByteSlice(val)
 		valCopy := make([]byte, len(valBytes))
 		copy(valCopy, valBytes)
 		results[keys[i]] = &CacheItem{
@@ -339,6 +339,17 @@ func (ms Memorystore) GetMulti(keys []string) (map[string]*CacheItem, error) {
 	}
 
 	return results, nil
+}
+
+func (ms Memorystore) convertToByteSlice(v interface{}) []byte {
+	switch v.(type) {
+	case string:
+		return []byte(v.(string))
+	case []byte:
+		return v.([]byte)
+	default:
+		panic(fmt.Sprintf("unsupported type for convert: %T, %+v", v, v))
+	}
 }
 
 func (ms Memorystore) Increment(key string, amount int64, initialValue uint64) (incr uint64, err error) {

--- a/memorystore_test.go
+++ b/memorystore_test.go
@@ -462,7 +462,7 @@ func (s *MemorystoreTest) TestGetMulti(c *C) {
 	}
 
 	// success case
-	keys := []string{"apple", "banana", "pear"}
+	keys := []string{"apple", "banana", "pear", "pineapple"}
 	fullKeys := make([]string, len(keys))
 	for i, key := range keys {
 		fullKeys[i] = ms.buildNamespacedKey(key)
@@ -471,6 +471,7 @@ func (s *MemorystoreTest) TestGetMulti(c *C) {
 		[]byte("apple tree"),
 		nil, // indicates not found
 		[]byte("pear tree"),
+		"pineapple shrub thing", // getMulti can return strings instead of byte slices
 	}
 	clientMock.On("MGet", fullKeys).Return(vals, nil).Once()
 	results, err := ms.GetMulti(keys)
@@ -485,6 +486,11 @@ func (s *MemorystoreTest) TestGetMulti(c *C) {
 			Key:            keys[2],
 			Value:          vals[2].([]byte),
 			valueOnLastGet: vals[2].([]byte),
+		},
+		"pineapple": {
+			Key:            keys[3],
+			Value:          []byte(vals[3].(string)),
+			valueOnLastGet: []byte(vals[3].(string)),
 		},
 	})
 	c.Assert(results["apple"].Value, Not(brace.SameMemoryAs), results["apple"].valueOnLastGet)


### PR DESCRIPTION
Redis GetMulti returns strings, at least sometimes.  Safely convert either
strings or byte slice interfaces to byte slices.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pendo-io/appwrap/34)
<!-- Reviewable:end -->
