### PR TITLE
APP-29623 - Add interface for HttpTarget cloud tasks

### DIFF
--- a/cloudtasksappengine.go
+++ b/cloudtasksappengine.go
@@ -1,0 +1,179 @@
+package appwrap
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/golang/protobuf/ptypes/timestamp"
+	taskspb "google.golang.org/genproto/googleapis/cloud/tasks/v2"
+)
+
+type cloudTaskAppEngineImpl struct {
+	task *taskspb.Task
+}
+
+func newAppEngineCloudTask() AppEngineTask {
+	return &cloudTaskAppEngineImpl{
+		task: &taskspb.Task{
+			MessageType: &taskspb.Task_AppEngineHttpRequest{
+				AppEngineHttpRequest: &taskspb.AppEngineHttpRequest{
+					AppEngineRouting: &taskspb.AppEngineRouting{},
+				},
+			},
+		},
+	}
+}
+
+func (t cloudTaskAppEngineImpl) Copy() CloudTask {
+	innerCopy := *t.task.GetAppEngineHttpRequest()
+	bodyCopy := make([]byte, len(innerCopy.Body))
+	copy(bodyCopy, innerCopy.Body)
+	headerCopy := make(map[string]string, len(innerCopy.Headers))
+	for k, v := range innerCopy.Headers {
+		headerCopy[k] = v
+	}
+	taskCopy := &cloudTaskAppEngineImpl{
+		task: &taskspb.Task{
+			MessageType: &taskspb.Task_AppEngineHttpRequest{
+				AppEngineHttpRequest: &taskspb.AppEngineHttpRequest{
+					AppEngineRouting: &taskspb.AppEngineRouting{
+						Service:  innerCopy.AppEngineRouting.Service,
+						Version:  innerCopy.AppEngineRouting.Version,
+						Instance: innerCopy.AppEngineRouting.Instance,
+						Host:     innerCopy.AppEngineRouting.Host,
+					},
+					HttpMethod:  innerCopy.HttpMethod,
+					Headers:     headerCopy,
+					Body:        bodyCopy,
+					RelativeUri: innerCopy.RelativeUri,
+				},
+			},
+		},
+	}
+	return taskCopy
+}
+
+func (t *cloudTaskAppEngineImpl) isTask() {}
+
+func (t *cloudTaskAppEngineImpl) Delay() (delay time.Duration) {
+	if sched := t.task.ScheduleTime; sched == nil {
+	} else {
+		delay = time.Unix(sched.Seconds, int64(sched.Nanos)).Sub(time.Now())
+	}
+	if delay < 0 {
+		return time.Duration(0)
+	}
+	return
+}
+
+func (t *cloudTaskAppEngineImpl) SetDelay(delay time.Duration) {
+	eta := time.Now().Add(delay)
+	t.SetEta(eta)
+}
+
+func (t *cloudTaskAppEngineImpl) SetEta(eta time.Time) {
+	t.task.ScheduleTime = &timestamp.Timestamp{
+		Seconds: eta.Unix(),
+		Nanos:   int32(eta.Nanosecond()),
+	}
+}
+
+func (t *cloudTaskAppEngineImpl) Name() string {
+	return t.task.Name
+}
+
+func (t *cloudTaskAppEngineImpl) SetName(name string) {
+	t.task.Name = name
+}
+
+func (t *cloudTaskAppEngineImpl) RetryCount() int32 {
+	return t.task.DispatchCount
+}
+
+func (t *cloudTaskAppEngineImpl) SetRetryCount(count int32) {
+	t.task.DispatchCount = count
+}
+
+func (t *cloudTaskAppEngineImpl) Tag() (tag string) {
+	panic("not implemented for CloudTasks")
+}
+
+func (t *cloudTaskAppEngineImpl) SetTag(tag string) {
+	panic("not implemented for CloudTasks")
+}
+
+func (t *cloudTaskAppEngineImpl) Header() http.Header {
+	req := t.task.GetAppEngineHttpRequest()
+	header := make(http.Header, len(req.Headers))
+	if req.Headers == nil {
+		return nil
+	}
+	for key, value := range req.Headers {
+		header[key] = []string{value}
+	}
+	return header
+}
+
+func (t *cloudTaskAppEngineImpl) SetHeader(header http.Header) {
+	req := t.task.GetAppEngineHttpRequest()
+	reqHeader := make(map[string]string, len(header))
+	for key, value := range header {
+		reqHeader[key] = value[0]
+	}
+	req.Headers = reqHeader
+}
+
+func (t *cloudTaskAppEngineImpl) Method() string {
+	req := t.task.GetAppEngineHttpRequest()
+	return taskspb.HttpMethod_name[int32(req.HttpMethod)]
+}
+
+func (t *cloudTaskAppEngineImpl) SetMethod(method string) {
+	if val := taskspb.HttpMethod_value[method]; val != 0 {
+		req := t.task.GetAppEngineHttpRequest()
+		req.HttpMethod = taskspb.HttpMethod(val)
+	} else {
+		panic(fmt.Sprintf("invalid task method: %s", method))
+	}
+}
+
+func (t *cloudTaskAppEngineImpl) Path() (path string) {
+	req := t.task.GetAppEngineHttpRequest()
+	return req.RelativeUri
+}
+
+func (t *cloudTaskAppEngineImpl) SetPath(path string) {
+	req := t.task.GetAppEngineHttpRequest()
+	req.RelativeUri = path
+}
+
+func (t *cloudTaskAppEngineImpl) Payload() []byte {
+	req := t.task.GetAppEngineHttpRequest()
+	return req.Body
+}
+
+func (t *cloudTaskAppEngineImpl) SetPayload(payload []byte) {
+	req := t.task.GetAppEngineHttpRequest()
+	req.Body = payload
+}
+
+func (t *cloudTaskAppEngineImpl) Service() (service string) {
+	routing := t.task.GetAppEngineHttpRequest().GetAppEngineRouting()
+	return routing.Service
+}
+
+func (t *cloudTaskAppEngineImpl) SetService(service string) {
+	routing := t.task.GetAppEngineHttpRequest().GetAppEngineRouting()
+	routing.Service = service
+}
+
+func (t *cloudTaskAppEngineImpl) Version() string {
+	routing := t.task.GetAppEngineHttpRequest().GetAppEngineRouting()
+	return routing.Version
+}
+
+func (t *cloudTaskAppEngineImpl) SetVersion(version string) {
+	routing := t.task.GetAppEngineHttpRequest().GetAppEngineRouting()
+	routing.Version = version
+}

--- a/cloudtaskshttp.go
+++ b/cloudtaskshttp.go
@@ -1,0 +1,174 @@
+package appwrap
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/golang/protobuf/ptypes/timestamp"
+	taskspb "google.golang.org/genproto/googleapis/cloud/tasks/v2"
+)
+
+type cloudTaskHttpImpl struct {
+	task *taskspb.Task
+}
+
+func newHttpCloudTask(serviceAccount string) HttpTask {
+	return &cloudTaskHttpImpl{
+		task: &taskspb.Task{
+			MessageType: &taskspb.Task_HttpRequest{
+				HttpRequest: &taskspb.HttpRequest{
+					AuthorizationHeader: &taskspb.HttpRequest_OidcToken{
+						OidcToken: &taskspb.OidcToken{
+							ServiceAccountEmail: serviceAccount,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (t cloudTaskHttpImpl) Copy() CloudTask {
+	innerCopy := *t.task.GetHttpRequest()
+	bodyCopy := make([]byte, len(innerCopy.Body))
+	copy(bodyCopy, innerCopy.Body)
+	headerCopy := make(map[string]string, len(innerCopy.Headers))
+	for k, v := range innerCopy.Headers {
+		headerCopy[k] = v
+	}
+	serviceAccountCopy := make([]byte, len(innerCopy.GetOidcToken().ServiceAccountEmail))
+	copy(serviceAccountCopy, innerCopy.GetOidcToken().ServiceAccountEmail)
+	taskCopy := &cloudTaskHttpImpl{
+		task: &taskspb.Task{
+			MessageType: &taskspb.Task_HttpRequest{
+				HttpRequest: &taskspb.HttpRequest{
+					HttpMethod: innerCopy.HttpMethod,
+					Headers:    headerCopy,
+					Body:       bodyCopy,
+					Url:        innerCopy.Url,
+					AuthorizationHeader: &taskspb.HttpRequest_OidcToken{
+						OidcToken: &taskspb.OidcToken{
+							ServiceAccountEmail: string(serviceAccountCopy),
+						},
+					},
+				},
+			},
+		},
+	}
+	return taskCopy
+}
+
+func (t *cloudTaskHttpImpl) isTask() {}
+
+func (t *cloudTaskHttpImpl) Delay() (delay time.Duration) {
+	if sched := t.task.ScheduleTime; sched == nil {
+	} else {
+		delay = time.Unix(sched.Seconds, int64(sched.Nanos)).Sub(time.Now())
+	}
+	if delay < 0 {
+		return time.Duration(0)
+	}
+	return
+}
+
+func (t *cloudTaskHttpImpl) SetDelay(delay time.Duration) {
+	eta := time.Now().Add(delay)
+	t.SetEta(eta)
+}
+
+func (t *cloudTaskHttpImpl) SetEta(eta time.Time) {
+	t.task.ScheduleTime = &timestamp.Timestamp{
+		Seconds: eta.Unix(),
+		Nanos:   int32(eta.Nanosecond()),
+	}
+}
+
+func (t *cloudTaskHttpImpl) Name() string {
+	return t.task.Name
+}
+
+func (t *cloudTaskHttpImpl) SetName(name string) {
+	t.task.Name = name
+}
+
+func (t *cloudTaskHttpImpl) RetryCount() int32 {
+	return t.task.DispatchCount
+}
+
+func (t *cloudTaskHttpImpl) SetRetryCount(count int32) {
+	t.task.DispatchCount = count
+}
+
+func (t *cloudTaskHttpImpl) Tag() (tag string) {
+	panic("not implemented for CloudTasks")
+}
+
+func (t *cloudTaskHttpImpl) SetTag(tag string) {
+	panic("not implemented for CloudTasks")
+}
+
+func (t *cloudTaskHttpImpl) Header() http.Header {
+	req := t.task.GetHttpRequest()
+	header := make(http.Header, len(req.Headers))
+	if req.Headers == nil {
+		return nil
+	}
+	for key, value := range req.Headers {
+		header[key] = []string{value}
+	}
+	return header
+}
+
+func (t *cloudTaskHttpImpl) SetHeader(header http.Header) {
+	req := t.task.GetHttpRequest()
+	reqHeader := make(map[string]string, len(header))
+	for key, value := range header {
+		reqHeader[key] = value[0]
+	}
+	req.Headers = reqHeader
+}
+
+func (t *cloudTaskHttpImpl) Method() string {
+	req := t.task.GetHttpRequest()
+	return taskspb.HttpMethod_name[int32(req.HttpMethod)]
+}
+
+func (t *cloudTaskHttpImpl) SetMethod(method string) {
+	if val := taskspb.HttpMethod_value[method]; val != 0 {
+		req := t.task.GetHttpRequest()
+		req.HttpMethod = taskspb.HttpMethod(val)
+	} else {
+		panic(fmt.Sprintf("invalid task method: %s", method))
+	}
+}
+
+func (t *cloudTaskHttpImpl) Url() string {
+	req := t.task.GetHttpRequest()
+	return req.Url
+}
+
+func (t *cloudTaskHttpImpl) SetUrl(url string) {
+	req := t.task.GetHttpRequest()
+	req.Url = url
+}
+
+func (t *cloudTaskHttpImpl) Payload() []byte {
+	req := t.task.GetHttpRequest()
+	return req.Body
+}
+
+func (t *cloudTaskHttpImpl) SetPayload(payload []byte) {
+	req := t.task.GetHttpRequest()
+	req.Body = payload
+}
+
+func (t cloudTaskqueue) NewHttpCloudTask(queueName string, url string, method string, data []byte, headers http.Header) HttpTask {
+	task := NewHttpCloudTask(queueName)
+	headers.Set("Content-Type", "application/json")
+	task.SetMethod(method)
+	task.SetPayload(data)
+	task.SetHeader(headers)
+	task.SetUrl(url)
+	return task
+}

--- a/cloudtaskshttp_test.go
+++ b/cloudtaskshttp_test.go
@@ -1,0 +1,249 @@
+package appwrap
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/googleapis/gax-go/v2"
+	taskspb "google.golang.org/genproto/googleapis/cloud/tasks/v2"
+	. "gopkg.in/check.v1"
+)
+
+type HttpCloudTasksTest struct{}
+
+var _ = Suite(&HttpCloudTasksTest{})
+
+func (s *HttpCloudTasksTest) SetUpTest(c *C) {
+	var client cloudTasksClient = &tqClientMock{}
+	tqClient = &client
+}
+
+func (s *HttpCloudTasksTest) TestCloudTaskCopy(c *C) {
+	task := &cloudTaskHttpImpl{
+		task: &taskspb.Task{
+			MessageType: &taskspb.Task_HttpRequest{
+				HttpRequest: &taskspb.HttpRequest{
+					HttpMethod: taskspb.HttpMethod_POST,
+					Headers: map[string]string{
+						"key": "value",
+					},
+					Body: []byte("body"),
+					Url:  "https://api.example.com/vegetables/potato",
+					AuthorizationHeader: &taskspb.HttpRequest_OidcToken{
+						OidcToken: &taskspb.OidcToken{
+							ServiceAccountEmail: "feedback@service.account",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	taskCopy := task.Copy().(*cloudTaskHttpImpl)
+	//c.Assert(task, DeepEquals, taskCopy)
+	// verify that all pointers and slices are different locations in memory
+	c.Assert(task, Not(Equals), taskCopy)
+	c.Assert(task.task, Not(Equals), taskCopy.task)
+	c.Assert(task.task.GetHttpRequest().AuthorizationHeader, Not(Equals), taskCopy.task.GetHttpRequest().AuthorizationHeader)
+	c.Assert(task.task.GetHttpRequest().GetOidcToken(), Not(Equals), taskCopy.task.GetHttpRequest().GetOidcToken())
+	c.Assert(task.task.GetMessageType(), Not(Equals), taskCopy.task.GetMessageType())
+	c.Assert(task.task.GetHttpRequest(), Not(Equals), taskCopy.task.GetHttpRequest())
+	c.Assert(sameMemory(task.task.GetHttpRequest().Headers, taskCopy.task.GetHttpRequest().Headers), IsFalse)
+	c.Assert(sameMemory(task.task.GetHttpRequest().Body, taskCopy.task.GetHttpRequest().Body), IsFalse)
+
+	// modifying one shouldn't touch the other
+	task.task.GetHttpRequest().Body[0] = 'a'
+	c.Assert(task.task.GetHttpRequest().Body, DeepEquals, []byte("aody"))
+	c.Assert(taskCopy.task.GetHttpRequest().Body, DeepEquals, []byte("body"))
+}
+
+func (s *HttpCloudTasksTest) TestNewHttpTask(c *C) {
+	task := NewHttpCloudTask("foo@example.com").(*cloudTaskHttpImpl)
+	c.Assert(task.task, DeepEquals, &taskspb.Task{
+		MessageType: &taskspb.Task_HttpRequest{
+			HttpRequest: &taskspb.HttpRequest{
+				AuthorizationHeader: &taskspb.HttpRequest_OidcToken{
+					OidcToken: &taskspb.OidcToken{
+						ServiceAccountEmail: "foo@example.com",
+					},
+				},
+			},
+		}},
+	)
+}
+
+func (s *HttpCloudTasksTest) TestHttpTaskDelay(c *C) {
+	task := NewHttpCloudTask("foo@example.com").(*cloudTaskHttpImpl)
+
+	storedDelay := task.Delay()
+	c.Assert(storedDelay, Equals, time.Duration(0))
+
+	delay := 10 * time.Second
+	task.SetDelay(delay)
+	<-time.After(time.Millisecond)
+
+	storedDelay = task.Delay()
+	c.Assert(storedDelay > 9*time.Second, IsTrue)
+	c.Assert(storedDelay < 10*time.Second, IsTrue)
+
+	task.SetEta(time.Now().Add(20 * time.Second))
+	<-time.After(time.Millisecond)
+	storedDelay = task.Delay()
+	c.Assert(storedDelay > 19*time.Second, IsTrue)
+	c.Assert(storedDelay < 20*time.Second, IsTrue)
+
+	delay = -10 * time.Second
+	task.SetDelay(delay)
+	c.Assert(task.Delay(), Equals, time.Duration(0))
+}
+
+func (s *HttpCloudTasksTest) TestHttpTaskHeader(c *C) {
+	task := NewHttpCloudTask("feedback@service.account")
+
+	storedHeader := task.Header()
+	c.Assert(storedHeader, DeepEquals, http.Header(nil))
+
+	header := http.Header{}
+	task.SetHeader(header)
+
+	storedHeader = task.Header()
+	c.Assert(storedHeader, DeepEquals, http.Header{})
+
+	header = http.Header{
+		"fruit":          {"apple"},
+		"multiple-fruit": {"blueberry", "raspberry"},
+	}
+
+	// don't support multiple values, should take first value of each set
+	expectedHeader := http.Header{
+		"fruit":          {"apple"},
+		"multiple-fruit": {"blueberry"},
+	}
+
+	task.SetHeader(header)
+	storedHeader = task.Header()
+
+	c.Assert(storedHeader, DeepEquals, expectedHeader)
+}
+
+func (s *HttpCloudTasksTest) TestHttpTaskMethod(c *C) {
+	task := NewHttpCloudTask("feedback@service.account")
+
+	storedMethod := task.Method()
+	c.Assert(storedMethod, Equals, "HTTP_METHOD_UNSPECIFIED")
+
+	for _, method := range []string{"GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"} {
+		task.SetMethod(method)
+		storedMethod = task.Method()
+		c.Assert(storedMethod, Equals, method)
+	}
+
+	shouldPanic := func() {
+		task.SetMethod("BANANA")
+	}
+	c.Assert(shouldPanic, PanicMatches, "invalid task method: BANANA")
+	// should still be last set method
+	storedMethod = task.Method()
+	c.Assert(storedMethod, Equals, "OPTIONS")
+}
+
+func (s *HttpCloudTasksTest) TestHttpTaskName(c *C) {
+	task := NewHttpCloudTask("feedback@service.account")
+
+	storedName := task.Name()
+	c.Assert(storedName, Equals, "")
+
+	task.SetName("names are hard")
+	storedName = task.Name()
+	c.Assert(storedName, Equals, "names are hard")
+}
+
+func (s *HttpCloudTasksTest) TestHttpTaskPayload(c *C) {
+	task := NewHttpCloudTask("feedback@service.account")
+
+	storedPayload := task.Payload()
+	c.Assert(bytes.Equal(storedPayload, []byte{}), IsTrue)
+
+	task.SetPayload([]byte("buzz buzz I'm a bee"))
+	storedPayload = task.Payload()
+	c.Assert(bytes.Equal(storedPayload, []byte("buzz buzz I'm a bee")), IsTrue)
+}
+
+func (s *HttpCloudTasksTest) TestHttpTaskRetryCount(c *C) {
+	task := NewHttpCloudTask("feedback@service.account")
+
+	storedCount := task.RetryCount()
+	c.Assert(storedCount, Equals, int32(0))
+
+	task.SetRetryCount(int32(93))
+	storedCount = task.RetryCount()
+	c.Assert(storedCount, Equals, int32(93))
+}
+
+func (m *tqClientMock) CreateHttpTask(ctx context.Context, req *taskspb.CreateTaskRequest, opts ...gax.CallOption) (*taskspb.Task, error) {
+	args := m.Called(ctx, req, opts)
+	return args.Get(0).(*taskspb.Task), args.Error(1)
+}
+
+func (s *HttpCloudTasksTest) TestNewHttpPOSTTask(c *C) {
+	location := CloudTasksLocation("disney-world")
+	ctx := context.Background()
+
+	tq := NewTaskqueue(ctx, location).(cloudTaskqueue)
+	headers := make(http.Header)
+	headers.Set("Content-Type", "application/json")
+	task := tq.NewHttpCloudTask("foo@example.com", "https://api.example.com/vegetables/potato", http.MethodPost, []byte("{ vegetables: [{'type': 'Russet', 'tasty': true] }"), headers).(*cloudTaskHttpImpl)
+	c.Assert(task, DeepEquals, &cloudTaskHttpImpl{
+		task: &taskspb.Task{
+			MessageType: &taskspb.Task_HttpRequest{
+				HttpRequest: &taskspb.HttpRequest{
+					Url:        "https://api.example.com/vegetables/potato",
+					HttpMethod: taskspb.HttpMethod_POST,
+					Headers: map[string]string{
+						"Content-Type": "application/json",
+					},
+					Body: []byte("{ vegetables: [{'type': 'Russet', 'tasty': true] }"),
+					AuthorizationHeader: &taskspb.HttpRequest_OidcToken{
+						OidcToken: &taskspb.OidcToken{
+							ServiceAccountEmail: "foo@example.com",
+						},
+					},
+				},
+			},
+		},
+	})
+}
+
+func (s *HttpCloudTasksTest) TestHttpAdd(c *C) {
+	location := CloudTasksLocation("disney-world")
+	ctx := context.Background()
+
+	tq := NewTaskqueue(ctx, location).(cloudTaskqueue)
+	tq.project = "shopping"
+	clientMock := tq.client.(*tqClientMock)
+
+	checkMocks := func() {
+		clientMock.AssertExpectations(c)
+	}
+
+	data := "{ vegetables: [{'type': 'Russet', 'tasty': true] }"
+	headers := make(http.Header)
+	headers.Set("Content-Type", "application/json")
+	task := tq.NewHttpCloudTask("foo@example.com", "https://api.example.com/vegetables/potato", http.MethodPost, []byte(data), headers).(*cloudTaskHttpImpl)
+	expectTask := task.Copy().(*cloudTaskHttpImpl)
+
+	clientMock.On("CreateTask", context.Background(), &taskspb.CreateTaskRequest{
+		Task:   task.task,
+		Parent: "projects/shopping/locations/disney-world/queues/grocery-store",
+	}, []gax.CallOption(nil)).Return(task.task, nil).Once()
+
+	added, err := tq.Add(ctx, task, "grocery-store")
+	c.Assert(added, Not(Equals), expectTask)                    // not same pointer (copied)...
+	_, isHttpTask := added.(HttpTask)
+	c.Assert(isHttpTask, IsTrue)
+	c.Assert(added.(*cloudTaskHttpImpl).task, DeepEquals, expectTask.task) // ...but has same content
+	c.Assert(err, IsNil)
+	checkMocks()
+}


### PR DESCRIPTION
- Add public API functions to allow enqueueing of Http target cloud task tasks
- Rename `Task` -> `AppEngineTask` to avoid ambiguity and confusion now we support both.
- Rename files to match the new interface naming


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pendo-io/appwrap/85)
<!-- Reviewable:end -->
