### PR TITLE
APP-32626 use max 30 min timeout for http cloud tasks

### DIFF
--- a/cloudtaskshttp.go
+++ b/cloudtaskshttp.go
@@ -2,10 +2,10 @@ package appwrap
 
 import (
 	"fmt"
-	"github.com/golang/protobuf/ptypes/duration"
 	"net/http"
 	"time"
 
+	"github.com/golang/protobuf/ptypes/duration"
 	"github.com/golang/protobuf/ptypes/timestamp"
 	taskspb "google.golang.org/genproto/googleapis/cloud/tasks/v2"
 )

--- a/cloudtaskshttp.go
+++ b/cloudtaskshttp.go
@@ -2,10 +2,10 @@ package appwrap
 
 import (
 	"fmt"
+	"github.com/golang/protobuf/ptypes/duration"
 	"net/http"
 	"time"
 
-	"github.com/golang/protobuf/ptypes/duration"
 	"github.com/golang/protobuf/ptypes/timestamp"
 	taskspb "google.golang.org/genproto/googleapis/cloud/tasks/v2"
 )
@@ -39,10 +39,12 @@ func (t cloudTaskHttpImpl) Copy() CloudTask {
 	for k, v := range innerCopy.Headers {
 		headerCopy[k] = v
 	}
+	deadlineCopy := t.task.DispatchDeadline
 	serviceAccountCopy := make([]byte, len(innerCopy.GetOidcToken().ServiceAccountEmail))
 	copy(serviceAccountCopy, innerCopy.GetOidcToken().ServiceAccountEmail)
 	taskCopy := &cloudTaskHttpImpl{
 		task: &taskspb.Task{
+			DispatchDeadline: deadlineCopy,
 			MessageType: &taskspb.Task_HttpRequest{
 				HttpRequest: &taskspb.HttpRequest{
 					HttpMethod: innerCopy.HttpMethod,
@@ -58,6 +60,7 @@ func (t cloudTaskHttpImpl) Copy() CloudTask {
 			},
 		},
 	}
+
 	return taskCopy
 }
 

--- a/cloudtaskshttp.go
+++ b/cloudtaskshttp.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/golang/protobuf/ptypes/duration"
 	"github.com/golang/protobuf/ptypes/timestamp"
 	taskspb "google.golang.org/genproto/googleapis/cloud/tasks/v2"
 )
@@ -16,6 +17,7 @@ type cloudTaskHttpImpl struct {
 func newHttpCloudTask(serviceAccount string) HttpTask {
 	return &cloudTaskHttpImpl{
 		task: &taskspb.Task{
+			DispatchDeadline: &duration.Duration{Seconds: 1800},
 			MessageType: &taskspb.Task_HttpRequest{
 				HttpRequest: &taskspb.HttpRequest{
 					AuthorizationHeader: &taskspb.HttpRequest_OidcToken{

--- a/cloudtaskshttp_test.go
+++ b/cloudtaskshttp_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/golang/protobuf/ptypes/duration"
 	"github.com/googleapis/gax-go/v2"
 	taskspb "google.golang.org/genproto/googleapis/cloud/tasks/v2"
 	. "gopkg.in/check.v1"
@@ -23,6 +24,7 @@ func (s *HttpCloudTasksTest) SetUpTest(c *C) {
 func (s *HttpCloudTasksTest) TestCloudTaskCopy(c *C) {
 	task := &cloudTaskHttpImpl{
 		task: &taskspb.Task{
+			DispatchDeadline: &duration.Duration{Seconds: 1800},
 			MessageType: &taskspb.Task_HttpRequest{
 				HttpRequest: &taskspb.HttpRequest{
 					HttpMethod: taskspb.HttpMethod_POST,
@@ -62,6 +64,7 @@ func (s *HttpCloudTasksTest) TestCloudTaskCopy(c *C) {
 func (s *HttpCloudTasksTest) TestNewHttpTask(c *C) {
 	task := NewHttpCloudTask("foo@example.com").(*cloudTaskHttpImpl)
 	c.Assert(task.task, DeepEquals, &taskspb.Task{
+		DispatchDeadline: &duration.Duration{Seconds: 1800},
 		MessageType: &taskspb.Task_HttpRequest{
 			HttpRequest: &taskspb.HttpRequest{
 				AuthorizationHeader: &taskspb.HttpRequest_OidcToken{
@@ -197,6 +200,7 @@ func (s *HttpCloudTasksTest) TestNewHttpPOSTTask(c *C) {
 	task := tq.NewHttpCloudTask("foo@example.com", "https://api.example.com/vegetables/potato", http.MethodPost, []byte("{ vegetables: [{'type': 'Russet', 'tasty': true] }"), headers).(*cloudTaskHttpImpl)
 	c.Assert(task, DeepEquals, &cloudTaskHttpImpl{
 		task: &taskspb.Task{
+			DispatchDeadline: &duration.Duration{Seconds: 1800},
 			MessageType: &taskspb.Task_HttpRequest{
 				HttpRequest: &taskspb.HttpRequest{
 					Url:        "https://api.example.com/vegetables/potato",


### PR DESCRIPTION
Default timeout for http tasks is 10 minutes, raising to 30 min. Taking the lazy approach to set this by default, but can parameterize if this messes things up for you @gr-eg.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pendo-io/appwrap/101)
<!-- Reviewable:end -->
