### PR TITLE
APP-37135 don't hardcode cloud task http content type header

### DIFF
--- a/cloudtaskshttp.go
+++ b/cloudtaskshttp.go
@@ -160,9 +160,8 @@ func (t *cloudTaskHttpImpl) SetPayload(payload []byte) {
 	req.Body = payload
 }
 
-func (t cloudTaskqueue) NewHttpCloudTask(queueName string, url string, method string, data []byte, headers http.Header) HttpTask {
-	task := NewHttpCloudTask(queueName)
-	headers.Set("Content-Type", "application/json")
+func (t cloudTaskqueue) NewHttpCloudTask(serviceAccount string, url string, method string, data []byte, headers http.Header) HttpTask {
+	task := NewHttpCloudTask(serviceAccount)
 	task.SetMethod(method)
 	task.SetPayload(data)
 	task.SetHeader(headers)


### PR DESCRIPTION
Removing the hardcoded `Content-Type` header for http target tasks and will pass that in from the pendo-appengine side (in my http target stuff & feedback). I'll have a pendo-appengine PR to update that.

Also fixing the param `queueName` to have the correct name `serviceAccount`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pendo-io/appwrap/118)
<!-- Reviewable:end -->
