### PR TITLE
localdatastore: NewKey actually follows namespace now

### DIFF
--- a/clouddatastore.go
+++ b/clouddatastore.go
@@ -602,6 +602,8 @@ func (ds *LocalDatastore) NewKey(kind string, sId string, iId int64, parent *Dat
 	var namespace string
 	if parent != nil {
 		namespace = parent.Namespace
+	} else if ds.namespace != "" {
+		namespace = ds.namespace
 	} else {
 		namespace = "s~memds" // this mirrors StubContext
 	}

--- a/localdatastore.go
+++ b/localdatastore.go
@@ -230,6 +230,7 @@ type LocalDatastore struct {
 	entities        map[string]*dsItem
 	emptyContext    context.Context
 	mtx             *sync.Mutex
+	namespace       string
 	namespaces      map[string]*LocalDatastore
 	parent          *LocalDatastore
 	addEntityFields bool
@@ -277,6 +278,7 @@ func (ds *LocalDatastore) Namespace(ns string) Datastore {
 
 	if _, exists := ds.namespaces[ns]; !exists {
 		ds.namespaces[ns] = NewLocalDatastore(ds.addEntityFields, nil).(*LocalDatastore)
+		ds.namespaces[ns].namespace = ns
 		ds.namespaces[ns].parent = ds
 	}
 
@@ -525,6 +527,7 @@ func (ds *LocalDatastore) RunInTransaction(f func(coreds DatastoreTransaction) e
 	dsCopy := &LocalDatastore{
 		lastId:       ds.lastId,
 		entities:     make(map[string]*dsItem),
+		namespace:    ds.namespace,
 		emptyContext: StubContext(),
 		mtx:          &sync.Mutex{},
 	}


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pendo-io/appwrap/130)
<!-- Reviewable:end -->
