### PR TITLE
errors: do not report Error severity logs to Google Error Reporting

### DIFF
--- a/error_reporting.go
+++ b/error_reporting.go
@@ -112,9 +112,6 @@ func (e *errorForwardingLogger) AddLabels(labels map[string]string) error {
 
 func (e *errorForwardingLogger) Errorf(format string, args ...interface{}) {
 	e.wrappedLogger.Errorf(format, args...)
-	e.forwardError(forwardedError{
-		msg: fmt.Sprintf(format, args...),
-	})
 }
 
 func (e *errorForwardingLogger) Criticalf(format string, args ...interface{}) {

--- a/error_reporting_test.go
+++ b/error_reporting_test.go
@@ -121,7 +121,7 @@ func (e *ErrorReportingTest) TestWarningf_OnlyForwards(c *C) {
 	wrapMe.AssertExpectations(c)
 }
 
-func (e *ErrorReportingTest) TestErrorf_ForwardsAndReports(c *C) {
+func (e *ErrorReportingTest) TestErrorf_OnlyForwards(c *C) {
 	wrapMe := &LoggingMock{Log: &NullLogger{}}
 	mockReporter := &ErrorReporterMock{}
 	forwardLog := &errorForwardingLogger{
@@ -133,11 +133,6 @@ func (e *ErrorReportingTest) TestErrorf_ForwardsAndReports(c *C) {
 	}
 
 	wrapMe.On("Errorf", "silly %s. you broke it", "goose")
-	mockReporter.On("Report", ErrorReport{
-		Err:             forwardedError{msg: "silly goose. you broke it"},
-		Req:             nil,
-		ErrorAffectsKey: "",
-	})
 	forwardLog.Errorf("silly %s. you broke it", "goose")
 
 	wrapMe.AssertExpectations(c)
@@ -190,11 +185,6 @@ func (e *ErrorReportingTest) TestAddLabels_ErrorAffectsKeyIsSetToValue(c *C) {
 	wrapMe.On("AddLabels", labelsOne)
 	wrapMe.On("AddLabels", labelsTwo)
 	wrapMe.On("Errorf", "broken things!")
-	mockReporter.On("Report", ErrorReport{
-		Err:             forwardedError{msg: "broken things!"},
-		Req:             nil,
-		ErrorAffectsKey: "testSub",
-	})
 
 	err := forwardLog.AddLabels(labelsOne)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
Our Google Error reporting console is way too noisy to be useful, as many Errorf calls are things that are transient. Surface critical log messages only, which still includes stacktraces and panics.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pendo-io/appwrap/149)
<!-- Reviewable:end -->
