### PR TITLE
Implement TTL on IncrementInCache

### DIFF
--- a/localmemcache_test.go
+++ b/localmemcache_test.go
@@ -67,16 +67,21 @@ func (dsit *AppengineInterfacesTest) TestMemCacheIncrement(c *C) {
 	_, err := cache.IncrementExisting("k", 15)
 	c.Assert(err, Equals, ErrCacheMiss)
 
-	v, err := cache.Increment("k", 15, 10)
+	v, err := cache.Increment("k", 15, 10, time.Minute)
 	c.Assert(err, IsNil)
 	c.Assert(v, Equals, uint64(25))
 
 	v, err = cache.IncrementExisting("k", -10)
 	c.Assert(v, Equals, uint64(15))
 
-	v, err = cache.Increment("k", 1, 0)
-	c.Assert(v, Equals, uint64(16))
+	// specifying a TTL after the key is set for the first time should have no effect on the TTL
+	v, err = cache.Increment("k", 15, 15, time.Second)
+	c.Assert(err, IsNil)
+	c.Assert(v, Equals, uint64(30))
 
+	item, err := cache.Get("k")
+	c.Assert(err, IsNil)
+	c.Assert(item.Expiration, Equals, time.Minute)
 }
 
 func (dsit *AppengineInterfacesTest) TestMemCacheCAS(c *C) {

--- a/memcache.go
+++ b/memcache.go
@@ -12,7 +12,7 @@ type Memcache interface {
 	FlushShard(shard int) error
 	Get(key string) (*CacheItem, error)
 	GetMulti(keys []string) (map[string]*CacheItem, error)
-	Increment(key string, amount int64, initialValue uint64) (uint64, error)
+	Increment(key string, amount int64, initialValue uint64, initialExpires time.Duration) (uint64, error)
 	IncrementExisting(key string, amount int64) (uint64, error)
 	Namespace(ns string) Memcache
 	Set(item *CacheItem) error

--- a/memorystore.go
+++ b/memorystore.go
@@ -772,7 +772,7 @@ func (ms Memorystore) convertToByteSlice(v interface{}) []byte {
 	}
 }
 
-func (ms Memorystore) Increment(key string, amount int64, initialValue uint64) (incr uint64, err error) {
+func (ms Memorystore) Increment(key string, amount int64, initialValue uint64, initialExpires time.Duration) (incr uint64, err error) {
 	fullKey, shard := ms.namespacedKeyAndShard(key)
 	c, span := ms.tracer.Start(ms.c, traceMemorystoreIncr)
 	defer span.End()
@@ -781,7 +781,7 @@ func (ms Memorystore) Increment(key string, amount int64, initialValue uint64) (
 	span.SetAttributes(labelShard(int64(shard)))
 
 	pipe := ms.clients[shard].TxPipeline()
-	pipe.SetNX(c, fullKey, initialValue, time.Duration(0))
+	pipe.SetNX(c, fullKey, initialValue, initialExpires)
 	pipe.IncrBy(c, fullKey, amount)
 
 	var res []redis.Cmder

--- a/memorystore_test.go
+++ b/memorystore_test.go
@@ -940,14 +940,14 @@ func (s *MemorystoreTest) TestIncrement(c *C) {
 	initialValue := uint64(1)
 	amount := int64(5)
 	clientMocks[0].On("TxPipeline").Return(pipeMock).Once()
-	pipeMock.On("SetNX", mock.Anything, fullKey, initialValue, time.Duration(0)).Once()
+	pipeMock.On("SetNX", mock.Anything, fullKey, initialValue, 5*time.Minute).Once()
 	pipeMock.On("IncrBy", mock.Anything, fullKey, amount).Once()
 	pipeMock.On("Exec", mock.Anything).Return([]redis.Cmder{
 		uncalledResultMock,
 		calledResultMock,
 	}, nil).Once()
 	calledResultMock.On("Val").Return(int64(40))
-	incr, err := ms.Increment(key, amount, initialValue)
+	incr, err := ms.Increment(key, amount, initialValue, 5*time.Minute)
 	c.Assert(err, IsNil)
 	c.Assert(incr, Equals, uint64(40))
 	checkMocks()
@@ -958,7 +958,7 @@ func (s *MemorystoreTest) TestIncrement(c *C) {
 	pipeMock.On("SetNX", mock.Anything, fullKey, initialValue, time.Duration(0)).Once()
 	pipeMock.On("IncrBy", mock.Anything, fullKey, amount).Once()
 	pipeMock.On("Exec", mock.Anything).Return(([]redis.Cmder)(nil), fatalErr).Once()
-	incr, err = ms.Increment(key, amount, initialValue)
+	incr, err = ms.Increment(key, amount, initialValue, 0)
 	c.Assert(err, Equals, fatalErr)
 	c.Assert(incr, Equals, uint64(0))
 	checkMocks()


### PR DESCRIPTION
> Honestly, we should fix IncrementInCache to specify a TTL. This is a bug. 
> The only change here I’d make is to change IncrementInCache to take a TTL argument (that is only used if the key needs creating; it doesn't modify the TTL after creation).

Tested Memcache and Redis against WIP rate limiting branch.

Tested locally and on a lookaside. Used cache tag to force memcache.

Verified that `IncrementInCache` now takes a TTL, and that the TTL is applied correctly if it is setting the key for the first time. Verified that subsequent increments do not modify the TTL.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pendo-io/appwrap/169)
<!-- Reviewable:end -->
