### PR TITLE
Use start time of request for timestamps vs the time at which it was …

### DIFF
--- a/aeloggingstackdriver.go
+++ b/aeloggingstackdriver.go
@@ -240,7 +240,7 @@ func RunFuncWithDedicatedLogger(c context.Context, simulatedUrl, traceId string,
 			},
 			Labels:    logCtxVal.getLabels(),
 			Severity:  sev,
-			Timestamp: time.Now(),
+			Timestamp: start,
 			Trace:     logCtxVal.trace,
 		})
 	}()
@@ -272,6 +272,7 @@ func WrapHandlerWithStackdriverLogger(h http.Handler, logName string, opts ...op
 	parentLogger := getLogger(aeInfo, lc, requestLogPath)
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
 		logCtxVal := getLogCtxVal(aeInfo, r, logger, "")
 		traceHeader := r.Header.Get("X-Cloud-Trace-Context")
 		if traceHeader != "" {
@@ -280,7 +281,6 @@ func WrapHandlerWithStackdriverLogger(h http.Handler, logName string, opts ...op
 			logCtxVal.trace = parent + "/traces/" + fmt.Sprintf("%d", rand.Int63())
 		}
 		ctx := context.WithValue(r.Context(), loggingCtxKey, logCtxVal)
-		start := time.Now()
 		sw := &statusWriter{
 			ResponseWriter: w,
 			status:         http.StatusOK, // default response if we don't explicitly set one
@@ -296,7 +296,7 @@ func WrapHandlerWithStackdriverLogger(h http.Handler, logName string, opts ...op
 			},
 			Labels:    logCtxVal.getLabels(),
 			Severity:  logging.Severity(logCtxVal.sev),
-			Timestamp: time.Now(),
+			Timestamp: start,
 			Trace:     logCtxVal.trace,
 		}
 		parentLogger.Log(e)

--- a/stackdriverlogging.go
+++ b/stackdriverlogging.go
@@ -181,7 +181,7 @@ func (sl StackdriverLogging) Close(w http.ResponseWriter) {
 			},
 			Labels:    sl.commonLabels,
 			Severity:  sl.maxSeverity,
-			Timestamp: time.Now(),
+			Timestamp: sl.start,
 			Trace:     sl.traceContext,
 		}
 
@@ -193,7 +193,7 @@ func (sl StackdriverLogging) Close(w http.ResponseWriter) {
 			},
 			Labels:    sl.commonLabels,
 			Severity:  sl.maxSeverity,
-			Timestamp: time.Now(),
+			Timestamp: sl.start,
 			Trace:     sl.traceContext,
 		}
 	}


### PR DESCRIPTION
…logged


Tests have cases for looking at the timestamp vs the start time on the child logs which should be unchanged. Only updated test cases for parent logs (the request logs)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pendo-io/appwrap/172)
<!-- Reviewable:end -->
